### PR TITLE
Add clinic settings, fix Pet-related bugs, and revamp Pet resource UI/UX

### DIFF
--- a/app/Enums/PetGender.php
+++ b/app/Enums/PetGender.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum PetGender: string implements HasColor, HasIcon, HasLabel
+{
+    case Male = 'Male';
+    case Female = 'Female';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Male => 'Macho',
+            self::Female => 'Hembra',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Male => 'info',
+            self::Female => 'warning',
+        };
+    }
+
+    public function getIcon(): ?string
+    {
+        return null;
+    }
+}

--- a/app/Enums/PetReproductionStatus.php
+++ b/app/Enums/PetReproductionStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum PetReproductionStatus: string implements HasColor, HasIcon, HasLabel
+{
+    case Normal = 'Normal';
+    case Castrated = 'Castrated';
+    case Sterilized = 'Sterilized';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Normal => __('Normal'),
+            self::Castrated => __('Castrated'),
+            self::Sterilized => __('Sterilized'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Normal => 'gray',
+            self::Castrated => 'success',
+            self::Sterilized => 'success',
+        };
+    }
+
+    public function getIcon(): ?string
+    {
+        return null;
+    }
+}

--- a/app/Enums/PetSize.php
+++ b/app/Enums/PetSize.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum PetSize: string implements HasColor, HasIcon, HasLabel
+{
+    case Giant = 'Giant';
+    case Big = 'Big';
+    case Medium = 'Medium';
+    case Small = 'Small';
+    case Tiny = 'Tiny';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Giant => __('Giant'),
+            self::Big => __('Big'),
+            self::Medium => __('Medium'),
+            self::Small => __('Small'),
+            self::Tiny => __('Tiny'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Giant => 'danger',
+            self::Big => 'warning',
+            self::Medium => 'info',
+            self::Small => 'success',
+            self::Tiny => 'gray',
+        };
+    }
+
+    public function getIcon(): ?string
+    {
+        return null;
+    }
+}

--- a/app/Enums/PetSpecies.php
+++ b/app/Enums/PetSpecies.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum PetSpecies: string implements HasColor, HasIcon, HasLabel
+{
+    case Canino = 'Canino';
+    case Felino = 'Felino';
+    case Roedor = 'Roedor';
+    case Ave = 'Ave';
+    case Equino = 'Equino';
+    case Bovino = 'Bovino';
+    case Pez = 'Pez';
+    case Reptil = 'Reptil';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Canino => __('Canine'),
+            self::Felino => __('Feline'),
+            self::Roedor => __('Rodent'),
+            self::Ave => __('Bird'),
+            self::Equino => __('Equine'),
+            self::Bovino => __('Bovine'),
+            self::Pez => __('Fish'),
+            self::Reptil => __('Reptile'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Canino => 'info',
+            self::Felino => 'warning',
+            self::Roedor => 'gray',
+            self::Ave => 'success',
+            self::Equino => 'primary',
+            self::Bovino => 'gray',
+            self::Pez => 'info',
+            self::Reptil => 'success',
+        };
+    }
+
+    public function getIcon(): ?string
+    {
+        return null;
+    }
+}

--- a/app/Filament/Pages/ClinicSettingsPage.php
+++ b/app/Filament/Pages/ClinicSettingsPage.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Settings\ClinicSettings;
+use Filament\Forms;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+
+class ClinicSettingsPage extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cog-6-tooth';
+
+    protected static ?string $navigationGroup = 'Configuración';
+
+    protected static ?string $navigationLabel = 'Datos de la clínica';
+
+    protected static ?string $title = 'Datos de la clínica';
+
+    protected static ?string $slug = 'clinic-settings';
+
+    protected static string $view = 'filament.pages.clinic-settings-page';
+
+    public ?array $data = [];
+
+    public static function canAccess(): bool
+    {
+        return auth()->user()?->hasRole('admin') ?? false;
+    }
+
+    public function mount(): void
+    {
+        $this->form->fill(app(ClinicSettings::class)->toArray());
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Section::make('Datos básicos')
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Nombre de la clínica')
+                            ->required(),
+                        Forms\Components\ColorPicker::make('primary_color')
+                            ->label('Color primario del panel'),
+                        Forms\Components\FileUpload::make('logo')
+                            ->label('Logo')
+                            ->image()
+                            ->directory('clinic'),
+                        Forms\Components\FileUpload::make('favicon')
+                            ->label('Favicon')
+                            ->image()
+                            ->directory('clinic'),
+                    ]),
+
+                Forms\Components\Section::make('Contacto y ubicación')
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\Textarea::make('address')
+                            ->label('Dirección')
+                            ->columnSpanFull(),
+                        Forms\Components\TextInput::make('phone')
+                            ->label('Teléfono')
+                            ->tel(),
+                        Forms\Components\TextInput::make('email')
+                            ->label('Email')
+                            ->email(),
+                        Forms\Components\TextInput::make('business_hours')
+                            ->label('Horario de atención'),
+                    ]),
+
+                Forms\Components\Section::make('Datos legales y fiscales')
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\TextInput::make('ruc')
+                            ->label('RUC'),
+                        Forms\Components\TextInput::make('razon_social')
+                            ->label('Razón social'),
+                    ]),
+
+                Forms\Components\Section::make('Redes sociales y web')
+                    ->columns(3)
+                    ->schema([
+                        Forms\Components\TextInput::make('facebook')
+                            ->label('Facebook')
+                            ->url(),
+                        Forms\Components\TextInput::make('instagram')
+                            ->label('Instagram')
+                            ->url(),
+                        Forms\Components\TextInput::make('website')
+                            ->label('Sitio web')
+                            ->url(),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function save(): void
+    {
+        $settings = app(ClinicSettings::class);
+        $settings->fill($this->form->getState());
+        $settings->save();
+
+        Notification::make()
+            ->title('Datos de la clínica guardados')
+            ->success()
+            ->send();
+    }
+}

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\ConsultationResource\Pages;
-use App\Filament\Resources\ConsultationResource\RelationManagers;
 use App\Models\Consultation;
 use App\Services\AIDiagnosticService;
 use Filament\Forms;
@@ -15,13 +14,16 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
 
 class ConsultationResource extends Resource
 {
     protected static ?string $model = Consultation::class;
-    protected static ?string $navigationGroup = 'Procedures';
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Historial clínico';
+
+    protected static ?string $navigationIcon = 'heroicon-o-chat-bubble-left-right';
+
     protected static ?string $modelLabel = 'consulta';
 
     public static function form(Form $form): Form
@@ -52,7 +54,7 @@ class ConsultationResource extends Resource
                                     ->send();
                             }
                         })
-                        ->hidden(fn($record) => $record === null || !auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
+                        ->hidden(fn ($record) => $record === null || ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
                 ])->columnSpanFull(),
                 Forms\Components\Textarea::make('diagnosis')
                     ->translateLabel()
@@ -67,7 +69,7 @@ class ConsultationResource extends Resource
                 Forms\Components\Textarea::make('observation')
                     ->translateLabel()
                     ->columnSpanFull()
-                    ->autosize()
+                    ->autosize(),
             ]);
     }
 
@@ -106,7 +108,17 @@ class ConsultationResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\Filter::make('created_at')
+                    ->translateLabel()
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('Desde')->native(false),
+                        Forms\Components\DatePicker::make('until')->label('Hasta')->native(false),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'], fn (Builder $query, $date) => $query->whereDate('created_at', '>=', $date))
+                            ->when($data['until'], fn (Builder $query, $date) => $query->whereDate('created_at', '<=', $date));
+                    }),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
@@ -129,12 +141,12 @@ class ConsultationResource extends Resource
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }

--- a/app/Filament/Resources/ConsultationResource/Pages/ManageConsultations.php
+++ b/app/Filament/Resources/ConsultationResource/Pages/ManageConsultations.php
@@ -11,4 +11,15 @@ class ManageConsultations extends ManageRecords
 {
     protected static string $resource = ConsultationResource::class;
 
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->mutateFormDataUsing(function (array $data): array {
+                    $data['user_id'] = Auth::id();
+
+                    return $data;
+                }),
+        ];
+    }
 }

--- a/app/Filament/Resources/OwnerResource.php
+++ b/app/Filament/Resources/OwnerResource.php
@@ -15,14 +15,17 @@ use Filament\Forms\Set;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 class OwnerResource extends Resource
 {
     protected static ?string $model = Owner::class;
+
+    protected static ?string $navigationGroup = 'Pacientes';
+
     protected static ?string $navigationIcon = 'heroicon-o-user';
+
     protected static ?string $modelLabel = 'propietario';
 
     public static function form(Form $form): Form
@@ -81,16 +84,16 @@ class OwnerResource extends Resource
                             ->translateLabel()
                             ->required(),
                         Forms\Components\Select::make('city_id')
-                            ->options(fn(Get $get): Collection => City::query()->where('department_id', $get('department_id'))->pluck('name', 'id'))
+                            ->options(fn (Get $get): Collection => City::query()->where('department_id', $get('department_id'))->pluck('name', 'id'))
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->afterStateUpdated(fn(Set $set) => $set('neighborhood_id', null))
+                            ->afterStateUpdated(fn (Set $set) => $set('neighborhood_id', null))
                             ->label(__('City'))
                             ->translateLabel()
                             ->required(),
                         Forms\Components\Select::make('neighborhood_id')
-                            ->options(fn(Get $get): Collection => Neighborhood::query()->where('city_id', $get('city_id'))->pluck('name', 'id'))
+                            ->options(fn (Get $get): Collection => Neighborhood::query()->where('city_id', $get('city_id'))->pluck('name', 'id'))
                             ->searchable()
                             ->preload()
                             ->label(__('Neighborhood'))
@@ -175,7 +178,11 @@ class OwnerResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\SelectFilter::make('department_id')
+                    ->relationship('department', 'name')
+                    ->label('Departamento')
+                    ->searchable()
+                    ->preload(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
@@ -197,12 +204,12 @@ class OwnerResource extends Resource
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian', 'assistant']) ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian', 'assistant']) ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }

--- a/app/Filament/Resources/OwnerResource/RelationManagers/PetsRelationManager.php
+++ b/app/Filament/Resources/OwnerResource/RelationManagers/PetsRelationManager.php
@@ -2,20 +2,24 @@
 
 namespace App\Filament\Resources\OwnerResource\RelationManagers;
 
+use App\Enums\PetGender;
+use App\Enums\PetReproductionStatus;
+use App\Enums\PetSize;
+use App\Enums\PetSpecies;
 use Filament\Forms;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Auth;
 
 class PetsRelationManager extends RelationManager
 {
     protected static string $relationship = 'pets';
+
     protected static ?string $modelLabel = 'mascota';
+
     protected static ?string $title = 'Mascotas asociadas';
 
     public function canViewAny(): bool
@@ -58,16 +62,7 @@ class PetsRelationManager extends RelationManager
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->options([
-                                'Canino' => __('Canine'),
-                                'Felino' => __('Feline'),
-                                'Roedor' => __('Rodent'),
-                                'Ave' => __('Bird'),
-                                'Equino' => __('Equine'),
-                                'Bovino' => __('Bovine'),
-                                'Pez' => __('Fish'),
-                                'Reptil' => __('Reptile'),
-                            ])
+                            ->options(PetSpecies::class)
                             ->required(),
                         Forms\Components\TextInput::make('breed')
                             ->translateLabel()
@@ -84,10 +79,7 @@ class PetsRelationManager extends RelationManager
                         Forms\Components\Radio::make('gender')
                             ->translateLabel()
                             ->required()
-                            ->options([
-                                'Male' => 'Macho',
-                                'Female' => 'Hembra',
-                            ])
+                            ->options(PetGender::class)
                             ->inline()
                             ->inlineLabel(false),
                         Forms\Components\Select::make('reproduction')
@@ -95,11 +87,7 @@ class PetsRelationManager extends RelationManager
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->options([
-                                'Normal' => __('Normal'),
-                                'Castrated' => __('Castrated'),
-                                'Sterilized' => __('Sterilized'),
-                            ])
+                            ->options(PetReproductionStatus::class)
                             ->required(),
                         Forms\Components\Toggle::make('active')
                             ->translateLabel()
@@ -117,13 +105,7 @@ class PetsRelationManager extends RelationManager
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->options([
-                                'Giant' => __('Giant'),
-                                'Big' => __('Big'),
-                                'Medium' => __('Medium'),
-                                'Small' => __('Small'),
-                                'Tiny' => __('Tiny'),
-                            ])
+                            ->options(PetSize::class)
                             ->required(),
                         Forms\Components\TextInput::make('weight')
                             ->translateLabel()
@@ -145,7 +127,7 @@ class PetsRelationManager extends RelationManager
                             ->columnSpanFull()
                             ->uploadingMessage('Subiendo archivo adjunto...')
                             ->required(),
-                    ])
+                    ]),
             ]);
     }
 
@@ -167,6 +149,7 @@ class PetsRelationManager extends RelationManager
                     ->sortable(),
                 Tables\Columns\TextColumn::make('species')
                     ->translateLabel()
+                    ->badge()
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('breed')
@@ -195,6 +178,7 @@ class PetsRelationManager extends RelationManager
                 Tables\Actions\CreateAction::make()
                     ->mutateFormDataUsing(function (array $data): array {
                         $data['user_id'] = Auth::id();
+
                         return $data;
                     }),
             ])

--- a/app/Filament/Resources/PetResource.php
+++ b/app/Filament/Resources/PetResource.php
@@ -2,6 +2,10 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\PetGender;
+use App\Enums\PetReproductionStatus;
+use App\Enums\PetSize;
+use App\Enums\PetSpecies;
 use App\Filament\Resources\PetResource\Pages;
 use App\Filament\Resources\PetResource\RelationManagers;
 use App\Models\Pet;
@@ -11,14 +15,14 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use Filament\Tables\Columns\Layout\Split;
+use Illuminate\Database\Eloquent\Model;
 
 class PetResource extends Resource
 {
     protected static ?string $model = Pet::class;
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationIcon = 'heroicon-o-identification';
+
     protected static ?string $modelLabel = 'mascota';
 
     public static function form(Form $form): Form
@@ -41,16 +45,7 @@ class PetResource extends Resource
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->options([
-                                'Canino' => __('Canine'),
-                                'Felino' => __('Feline'),
-                                'Roedor' => __('Rodent'),
-                                'Ave' => __('Bird'),
-                                'Equino' => __('Equine'),
-                                'Bovino' => __('Bovine'),
-                                'Pez' => __('Fish'),
-                                'Reptil' => __('Reptile'),
-                            ])
+                            ->options(PetSpecies::class)
                             ->required(),
                         Forms\Components\TextInput::make('breed')
                             ->translateLabel()
@@ -67,10 +62,7 @@ class PetResource extends Resource
                         Forms\Components\Radio::make('gender')
                             ->translateLabel()
                             ->required()
-                            ->options([
-                                'Male' => 'Macho',
-                                'Female' => 'Hembra',
-                            ])
+                            ->options(PetGender::class)
                             ->inline()
                             ->inlineLabel(false),
                         Forms\Components\Select::make('reproduction')
@@ -78,11 +70,7 @@ class PetResource extends Resource
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->options([
-                                'Normal' => __('Normal'),
-                                'Castrated' => __('Castrated'),
-                                'Sterilized' => __('Sterilized'),
-                            ])
+                            ->options(PetReproductionStatus::class)
                             ->required(),
                         Forms\Components\Toggle::make('active')
                             ->translateLabel()
@@ -107,13 +95,7 @@ class PetResource extends Resource
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->options([
-                                'Giant' => __('Giant'),
-                                'Big' => __('Big'),
-                                'Medium' => __('Medium'),
-                                'Small' => __('Small'),
-                                'Tiny' => __('Tiny'),
-                            ])
+                            ->options(PetSize::class)
                             ->required(),
                         Forms\Components\TextInput::make('weight')
                             ->translateLabel()
@@ -135,7 +117,7 @@ class PetResource extends Resource
                             ->columnSpanFull()
                             ->uploadingMessage('Subiendo archivo adjunto...')
                             ->required(),
-                    ])
+                    ]),
             ]);
     }
 
@@ -157,12 +139,16 @@ class PetResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('species')
                     ->translateLabel()
+                    ->badge()
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('breed')
                     ->translateLabel()
                     ->searchable()
                     ->sortable(),
+                Tables\Columns\TextColumn::make('age')
+                    ->label('Edad')
+                    ->getStateUsing(fn (Pet $record) => $record->age),
                 Tables\Columns\IconColumn::make('active')
                     ->translateLabel()
                     ->boolean()
@@ -171,6 +157,18 @@ class PetResource extends Resource
                     ->translateLabel()
                     ->searchable()
                     ->sortable(),
+                Tables\Columns\TextColumn::make('gender')
+                    ->translateLabel()
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('size')
+                    ->translateLabel()
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('reproduction')
+                    ->translateLabel()
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('user.name')
                     ->translateLabel()
                     ->sortable()
@@ -187,9 +185,21 @@ class PetResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\SelectFilter::make('species')
+                    ->translateLabel()
+                    ->options(PetSpecies::class)
+                    ->multiple(),
+                Tables\Filters\SelectFilter::make('size')
+                    ->translateLabel()
+                    ->options(PetSize::class),
+                Tables\Filters\SelectFilter::make('gender')
+                    ->translateLabel()
+                    ->options(PetGender::class),
+                Tables\Filters\TernaryFilter::make('active')
+                    ->label('Estado'),
             ])
             ->actions([
+                Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),
             ])
@@ -210,12 +220,12 @@ class PetResource extends Resource
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian', 'assistant']) ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian', 'assistant']) ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
@@ -235,6 +245,7 @@ class PetResource extends Resource
         return [
             'index' => Pages\ListPets::route('/'),
             'create' => Pages\CreatePet::route('/create'),
+            'view' => Pages\ViewPet::route('/{record}'),
             'edit' => Pages\EditPet::route('/{record}/edit'),
         ];
     }

--- a/app/Filament/Resources/PetResource.php
+++ b/app/Filament/Resources/PetResource.php
@@ -21,6 +21,8 @@ class PetResource extends Resource
 {
     protected static ?string $model = Pet::class;
 
+    protected static ?string $navigationGroup = 'Pacientes';
+
     protected static ?string $navigationIcon = 'heroicon-o-identification';
 
     protected static ?string $modelLabel = 'mascota';

--- a/app/Filament/Resources/PetResource/Pages/ViewPet.php
+++ b/app/Filament/Resources/PetResource/Pages/ViewPet.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Resources\PetResource\Pages;
+
+use App\Filament\Resources\PetResource;
+use Filament\Actions;
+use Filament\Infolists\Components\ImageEntry;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewPet extends ViewRecord
+{
+    protected static string $resource = PetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+
+    public function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make(__('ID information'))
+                    ->columns(3)
+                    ->schema([
+                        TextEntry::make('name')->translateLabel(),
+                        TextEntry::make('species')->translateLabel()->badge(),
+                        TextEntry::make('breed')->translateLabel(),
+                        TextEntry::make('age')->label('Edad'),
+                        TextEntry::make('gender')->translateLabel()->badge(),
+                        TextEntry::make('reproduction')->translateLabel()->badge(),
+                        TextEntry::make('active')->translateLabel()->badge()
+                            ->formatStateUsing(fn (bool $state): string => $state ? 'Activo' : 'Inactivo')
+                            ->color(fn (bool $state): string => $state ? 'success' : 'danger'),
+                        TextEntry::make('owner.first_name')->translateLabel()->label('Propietario'),
+                    ]),
+
+                Section::make(__('More information'))
+                    ->columns(3)
+                    ->schema([
+                        TextEntry::make('size')->translateLabel()->badge(),
+                        TextEntry::make('weight')->translateLabel()->suffix(' kg'),
+                        TextEntry::make('fur')->label(__('Pelage')),
+                        ImageEntry::make('image')->translateLabel()->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -12,13 +12,14 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Auth;
 
 class ConsultationsRelationManager extends RelationManager
 {
     protected static string $relationship = 'consultations';
+
     protected static ?string $modelLabel = 'consulta';
+
     protected static ?string $title = 'Consultas';
 
     public function canViewAny(): bool
@@ -55,7 +56,7 @@ class ConsultationsRelationManager extends RelationManager
                         ->label('Asistir con IA')
                         ->icon('heroicon-o-sparkles')
                         ->color('info')
-                        ->hidden(fn() => !auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                        ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
                         ->action(function (Get $get, Set $set, $livewire) {
                             try {
                                 $pet = $livewire->getOwnerRecord();
@@ -84,7 +85,7 @@ class ConsultationsRelationManager extends RelationManager
                 Forms\Components\Textarea::make('observation')
                     ->translateLabel()
                     ->columnSpanFull()
-                    ->autosize()
+                    ->autosize(),
             ]);
     }
 
@@ -118,12 +119,23 @@ class ConsultationsRelationManager extends RelationManager
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\Filter::make('created_at')
+                    ->translateLabel()
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('Desde')->native(false),
+                        Forms\Components\DatePicker::make('until')->label('Hasta')->native(false),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'], fn (Builder $query, $date) => $query->whereDate('created_at', '>=', $date))
+                            ->when($data['until'], fn (Builder $query, $date) => $query->whereDate('created_at', '<=', $date));
+                    }),
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make()
                     ->mutateFormDataUsing(function (array $data): array {
                         $data['user_id'] = Auth::id();
+
                         return $data;
                     }),
             ])

--- a/app/Filament/Resources/PetResource/RelationManagers/SurgeriesRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/SurgeriesRelationManager.php
@@ -2,12 +2,14 @@
 
 namespace App\Filament\Resources\PetResource\RelationManagers;
 
+use App\Filament\Resources\SurgeryResource;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
 
 class SurgeriesRelationManager extends RelationManager
 {
@@ -53,32 +55,7 @@ class SurgeriesRelationManager extends RelationManager
                     ->searchable()
                     ->preload()
                     ->live()
-                    ->options([
-                        'Esterilización' => __('Sterilization'),
-                        'Ovariohisterectomía' => __('Ovariohysterectomy'),
-                        'Castración' => __('Neutering'),
-                        'Cirugía Dental' => __('Dental Surgery'),
-                        'Extracción de Tumores' => __('Tumor Removal'),
-                        'Cirugía de Cuerpo Extraño' => __('Foreign Body Surgery'),
-                        'Reparación de Fracturas' => __('Fracture Repair'),
-                        'Cesárea' => __('Cesarean Section'),
-                        'Amputación' => __('Amputation'),
-                        'Enucleación Ocular' => __('Eye Enucleation'),
-                        'Cirugía de Ligamento Cruzado' => __('Cruciate Ligament Surgery'),
-                        'Gastropexia Preventiva' => __('Prophylactic Gastropexy'),
-                        'Desungulación' => __('Declawing'),
-                        'Herniorrafia' => __('Hernia Repair'),
-                        'Laparotomía Exploratoria' => __('Exploratory Laparotomy'),
-                        'Onychectomía' => __('Onychectomy'),
-                        'Cistotomía' => __('Cystotomy'),
-                        'Uretrostomía Perineal' => __('Perineal Urethrostomy'),
-                        'Esplenectomía' => __('Splenectomy'),
-                        'Tiroidectomía' => __('Thyroidectomy'),
-                        'Cirugía de Luxación de Rótula' => __('Patellar Luxation Surgery'),
-                        'Toracotomía' => __('Thoracotomy'),
-                        'Resección Intestinal' => __('Intestinal Resection'),
-                        'Cirugía de Glándulas Perianales' => __('Perianal Gland Surgery'),
-                    ])
+                    ->options(SurgeryResource::typeOptions())
                     ->required(),
                 Forms\Components\Textarea::make('observation')
                     ->translateLabel()
@@ -135,7 +112,12 @@ class SurgeriesRelationManager extends RelationManager
                     }),
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        $data['user_id'] = Auth::id();
+
+                        return $data;
+                    }),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/PetResource/RelationManagers/SurgeriesRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/SurgeriesRelationManager.php
@@ -8,12 +8,13 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class SurgeriesRelationManager extends RelationManager
 {
     protected static string $relationship = 'surgeries';
+
     protected static ?string $modelLabel = 'cirugía';
+
     protected static ?string $title = 'Cirugías';
 
     public function canViewAny(): bool
@@ -82,7 +83,7 @@ class SurgeriesRelationManager extends RelationManager
                 Forms\Components\Textarea::make('observation')
                     ->translateLabel()
                     ->autosize()
-                    ->columnSpanFull()
+                    ->columnSpanFull(),
             ]);
     }
 
@@ -121,7 +122,17 @@ class SurgeriesRelationManager extends RelationManager
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\Filter::make('date')
+                    ->translateLabel()
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('Desde')->native(false),
+                        Forms\Components\DatePicker::make('until')->label('Hasta')->native(false),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'], fn (Builder $query, $date) => $query->whereDate('date', '>=', $date))
+                            ->when($data['until'], fn (Builder $query, $date) => $query->whereDate('date', '<=', $date));
+                    }),
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make(),

--- a/app/Filament/Resources/PetResource/RelationManagers/TestsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/TestsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\PetResource\RelationManagers;
 
+use App\Filament\Resources\TestResource;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -54,20 +55,7 @@ class TestsRelationManager extends RelationManager
                     ->searchable()
                     ->preload()
                     ->live()
-                    ->options([
-                        'Hematología' => __('Hematology'),
-                        'Bioquímica' => __('Biochemistry'),
-                        'Inmunología' => __('Immunology'),
-                        'Microbiología' => __('Microbiology'),
-                        'Parasitología' => __('Parasitology'),
-                        'Uroanálisis' => __('Urinalysis'),
-                        'Coprología' => __('Fecal Analysis'),
-                        'Cultivo' => __('Culture'),
-                        'Prueba Rápida' => __('Rapid Test'),
-                        'PCR' => __('PCR'),
-                        'Serología' => __('Serology'),
-                        'Otros' => __('Others'),
-                    ])
+                    ->options(TestResource::typeOptions())
                     ->required(),
                 Forms\Components\FileUpload::make('result')
                     ->label('Resultados')

--- a/app/Filament/Resources/PetResource/RelationManagers/TestsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/TestsRelationManager.php
@@ -8,15 +8,15 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Auth;
 
 class TestsRelationManager extends RelationManager
 {
     protected static string $relationship = 'tests';
-    protected static ?string $modelLabel = 'prueba laboratorial';
-    protected static ?string $title = 'Pruebas Laboratoriales';
 
+    protected static ?string $modelLabel = 'prueba laboratorial';
+
+    protected static ?string $title = 'Pruebas Laboratoriales';
 
     public function canViewAny(): bool
     {
@@ -83,7 +83,7 @@ class TestsRelationManager extends RelationManager
                 Forms\Components\Textarea::make('observation')
                     ->translateLabel()
                     ->autosize()
-                    ->columnSpanFull()
+                    ->columnSpanFull(),
             ]);
     }
 
@@ -122,12 +122,23 @@ class TestsRelationManager extends RelationManager
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\Filter::make('date')
+                    ->translateLabel()
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('Desde')->native(false),
+                        Forms\Components\DatePicker::make('until')->label('Hasta')->native(false),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when($data['from'], fn (Builder $query, $date) => $query->whereDate('date', '>=', $date))
+                            ->when($data['until'], fn (Builder $query, $date) => $query->whereDate('date', '<=', $date));
+                    }),
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make()
                     ->mutateFormDataUsing(function (array $data): array {
                         $data['user_id'] = Auth::id();
+
                         return $data;
                     }),
             ])

--- a/app/Filament/Resources/PetResource/RelationManagers/VaccinationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/VaccinationsRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\PetResource\RelationManagers;
 
 use App\Models\Pet;
+use App\Settings\ClinicSettings;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -10,13 +11,14 @@ use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Auth;
 
 class VaccinationsRelationManager extends RelationManager
 {
     protected static string $relationship = 'vaccinations';
+
     protected static ?string $modelLabel = 'vacunación';
+
     protected static ?string $title = 'Vacunaciones';
 
     public function canViewAny(): bool
@@ -173,12 +175,18 @@ class VaccinationsRelationManager extends RelationManager
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\Filter::make('overdue')
+                    ->label('Vencidas')
+                    ->query(fn (Builder $query) => $query->where('next_application', '<', now())),
+                Tables\Filters\Filter::make('upcoming')
+                    ->label('Próximas (7 días)')
+                    ->query(fn (Builder $query) => $query->whereBetween('next_application', [now(), now()->addDays(7)])),
             ])
             ->headerActions([
                 Tables\Actions\CreateAction::make()
                     ->mutateFormDataUsing(function (array $data): array {
                         $data['user_id'] = Auth::id();
+
                         return $data;
                     }),
                 Tables\Actions\Action::make('downloadVaccineCard')
@@ -187,7 +195,7 @@ class VaccinationsRelationManager extends RelationManager
                     ->action(function () {
                         $pet = $this->getOwnerRecord(); // Obtenemos el Pet desde el contexto padre
 
-                        if (!$pet) {
+                        if (! $pet) {
                             throw new \Exception('Mascota no encontrada');
                         }
 
@@ -195,7 +203,8 @@ class VaccinationsRelationManager extends RelationManager
                             function () use ($pet) {
                                 echo Pdf::loadView('pdf.vaccine-card', [
                                     'pet' => $pet,
-                                    'vaccinations' => $pet->vaccinations // Accedemos a la relación
+                                    'vaccinations' => $pet->vaccinations, // Accedemos a la relación
+                                    'clinic' => app(ClinicSettings::class),
                                 ])->stream();
                             },
                             "Carnet-Vacunacion-{$pet->name}.pdf"

--- a/app/Filament/Resources/SurgeryResource.php
+++ b/app/Filament/Resources/SurgeryResource.php
@@ -3,41 +3,91 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\SurgeryResource\Pages;
-use App\Filament\Resources\SurgeryResource\RelationManagers;
 use App\Models\Surgery;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
 
 class SurgeryResource extends Resource
 {
     protected static ?string $model = Surgery::class;
-    protected static ?string $navigationGroup = 'Procedures';
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Historial clínico';
+
+    protected static ?string $navigationIcon = 'heroicon-o-scissors';
+
     protected static ?string $modelLabel = 'cirugía';
+
+    public static function typeOptions(): array
+    {
+        return [
+            'Esterilización' => __('Sterilization'),
+            'Ovariohisterectomía' => __('Ovariohysterectomy'),
+            'Castración' => __('Neutering'),
+            'Cirugía Dental' => __('Dental Surgery'),
+            'Extracción de Tumores' => __('Tumor Removal'),
+            'Cirugía de Cuerpo Extraño' => __('Foreign Body Surgery'),
+            'Reparación de Fracturas' => __('Fracture Repair'),
+            'Cesárea' => __('Cesarean Section'),
+            'Amputación' => __('Amputation'),
+            'Enucleación Ocular' => __('Eye Enucleation'),
+            'Cirugía de Ligamento Cruzado' => __('Cruciate Ligament Surgery'),
+            'Gastropexia Preventiva' => __('Prophylactic Gastropexy'),
+            'Desungulación' => __('Declawing'),
+            'Herniorrafia' => __('Hernia Repair'),
+            'Laparotomía Exploratoria' => __('Exploratory Laparotomy'),
+            'Onychectomía' => __('Onychectomy'),
+            'Cistotomía' => __('Cystotomy'),
+            'Uretrostomía Perineal' => __('Perineal Urethrostomy'),
+            'Esplenectomía' => __('Splenectomy'),
+            'Tiroidectomía' => __('Thyroidectomy'),
+            'Cirugía de Luxación de Rótula' => __('Patellar Luxation Surgery'),
+            'Toracotomía' => __('Thoracotomy'),
+            'Resección Intestinal' => __('Intestinal Resection'),
+            'Cirugía de Glándulas Perianales' => __('Perianal Gland Surgery'),
+            'Sutura de herida' => __('Wound Suture'),
+            'Extracción dental' => __('Dental Extraction'),
+            'Desobstrucción uretral' => __('Urethral Unblocking'),
+        ];
+    }
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                Forms\Components\Select::make('pet_id')
-                    ->relationship('pet', 'name')
-                    ->searchable(['name', 'id'])
-                    ->preload()
-                    ->live()
-                    ->required(),
-                Forms\Components\DatePicker::make('date')
-                    ->required()
-                    ->native(false)
-                    ->maxDate(now()),
-                Forms\Components\TextInput::make('type')
-                    ->required(),
-                Forms\Components\Textarea::make('observation')
-                    ->columnSpanFull()
+                Section::make(__('General information'))
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\Select::make('pet_id')
+                            ->translateLabel()
+                            ->relationship('pet', 'name')
+                            ->searchable(['name', 'id'])
+                            ->preload()
+                            ->live()
+                            ->required(),
+                        Forms\Components\DatePicker::make('date')
+                            ->translateLabel()
+                            ->required()
+                            ->native(false)
+                            ->displayFormat('d/m/Y')
+                            ->closeOnDateSelection()
+                            ->maxDate(now()),
+                        Forms\Components\Select::make('type')
+                            ->translateLabel()
+                            ->searchable()
+                            ->preload()
+                            ->live()
+                            ->options(self::typeOptions())
+                            ->required(),
+                        Forms\Components\Textarea::make('observation')
+                            ->translateLabel()
+                            ->autosize()
+                            ->columnSpanFull(),
+                    ]),
             ]);
     }
 
@@ -46,15 +96,24 @@ class SurgeryResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('pet.name')
+                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('date')
-                    ->date()
+                    ->translateLabel()
+                    ->date('d/m/Y')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('type')
+                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('observation')->limit(50)
+                Tables\Columns\TextColumn::make('observation')
+                    ->translateLabel()
+                    ->limit(50)
                     ->searchable(),
             ])
             ->filters([
@@ -81,12 +140,12 @@ class SurgeryResource extends Resource
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }

--- a/app/Filament/Resources/TestResource.php
+++ b/app/Filament/Resources/TestResource.php
@@ -3,45 +3,89 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\TestResource\Pages;
-use App\Filament\Resources\TestResource\RelationManagers;
 use App\Models\Test;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\Model;
 
 class TestResource extends Resource
 {
     protected static ?string $model = Test::class;
-    protected static ?string $navigationGroup = 'Procedures';
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Historial clínico';
+
+    protected static ?string $navigationIcon = 'heroicon-o-beaker';
+
     protected static ?string $modelLabel = 'prueba laboratorial';
+
     protected static ?string $pluralModelLabel = 'pruebas laboratoriales';
+
+    public static function typeOptions(): array
+    {
+        return [
+            'Hematología' => __('Hematology'),
+            'Bioquímica' => __('Biochemistry'),
+            'Inmunología' => __('Immunology'),
+            'Microbiología' => __('Microbiology'),
+            'Parasitología' => __('Parasitology'),
+            'Uroanálisis' => __('Urinalysis'),
+            'Coprología' => __('Fecal Analysis'),
+            'Cultivo' => __('Culture'),
+            'Prueba Rápida' => __('Rapid Test'),
+            'PCR' => __('PCR'),
+            'Serología' => __('Serology'),
+            'Otros' => __('Others'),
+        ];
+    }
 
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                Forms\Components\Select::make('pet_id')
-                    ->relationship('pet', 'name')
-                    ->searchable(['name', 'id'])
-                    ->preload()
-                    ->live()
-                    ->required(),
-                Forms\Components\DatePicker::make('date')
-                    ->required()
-                    ->native(false)
-                    ->maxDate(now()),
-                Forms\Components\TextInput::make('type')
-                    ->required()
-                    ->maxLength(60),
-                Forms\Components\TextInput::make('result')
-                    ->required(),
-                Forms\Components\Textarea::make('observation')
-                    ->columnSpanFull()
+                Section::make(__('General information'))
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\Select::make('pet_id')
+                            ->translateLabel()
+                            ->relationship('pet', 'name')
+                            ->searchable(['name', 'id'])
+                            ->preload()
+                            ->live()
+                            ->required(),
+                        Forms\Components\DatePicker::make('date')
+                            ->translateLabel()
+                            ->required()
+                            ->native(false)
+                            ->displayFormat('d/m/Y')
+                            ->closeOnDateSelection()
+                            ->maxDate(now()),
+                        Forms\Components\Select::make('type')
+                            ->translateLabel()
+                            ->searchable()
+                            ->preload()
+                            ->live()
+                            ->options(self::typeOptions())
+                            ->required(),
+                        Forms\Components\FileUpload::make('result')
+                            ->label('Resultados')
+                            ->multiple()
+                            ->maxParallelUploads(1)
+                            ->panelLayout('grid')
+                            ->openable()
+                            ->downloadable()
+                            ->uploadingMessage('Subiendo archivo adjunto...')
+                            ->maxFiles(5)
+                            ->columnSpanFull()
+                            ->required(),
+                        Forms\Components\Textarea::make('observation')
+                            ->translateLabel()
+                            ->autosize()
+                            ->columnSpanFull(),
+                    ]),
             ]);
     }
 
@@ -50,29 +94,45 @@ class TestResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('id')
+                    ->label('ID')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('pet.name')
+                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('date')
-                    ->date()
+                    ->translateLabel()
+                    ->date('d/m/Y')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('type')
+                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('result')
-                    ->searchable()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('observation')->limit(50)
+                    ->label('Resultados')
+                    ->getStateUsing(function (Test $record) {
+                        $files = $record->result;
+
+                        return is_array($files) && count($files) > 0 ? count($files).' archivo(s)' : '—';
+                    }),
+                Tables\Columns\TextColumn::make('observation')
+                    ->translateLabel()
+                    ->limit(50)
                     ->searchable(),
                 Tables\Columns\TextColumn::make('user.name')
+                    ->translateLabel()
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
+                    ->translateLabel()
+                    ->dateTime('d/m/Y H:i')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
-                    ->dateTime()
+                    ->translateLabel()
+                    ->dateTime('d/m/Y H:i')
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
@@ -100,12 +160,12 @@ class TestResource extends Resource
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -4,27 +4,30 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\UserResource\Pages;
 use App\Filament\Resources\UserResource\RelationManagers;
-use App\Models\User;
-use App\Models\Department;
 use App\Models\City;
 use App\Models\Neighborhood;
+use App\Models\User;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Get;
-use Filament\Forms\Set;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 class UserResource extends Resource
 {
     protected static ?string $model = User::class;
+
+    protected static ?string $navigationGroup = 'Administración';
+
     protected static ?string $navigationIcon = 'heroicon-o-user-group';
+
     protected static ?int $navigationSort = 2;
+
     protected static ?string $modelLabel = 'usuario';
 
     public static function form(Form $form): Form
@@ -51,9 +54,9 @@ class UserResource extends Resource
                         Forms\Components\Select::make('role')
                             ->label('Rol')
                             ->options([
-                                'admin'        => 'Administrador',
+                                'admin' => 'Administrador',
                                 'veterinarian' => 'Veterinario',
-                                'assistant'    => 'Asistente',
+                                'assistant' => 'Asistente',
                             ])
                             ->required(),
                     ]),
@@ -74,17 +77,17 @@ class UserResource extends Resource
                             ->required(),
 
                         Forms\Components\Select::make('city_id')
-                            ->options(fn(Get $get): Collection => City::query()->where('department_id', $get('department_id'))->pluck('name', 'id'))
+                            ->options(fn (Get $get): Collection => City::query()->where('department_id', $get('department_id'))->pluck('name', 'id'))
                             ->searchable()
                             ->preload()
                             ->live()
-                            ->afterStateUpdated(fn(Set $set) => $set('neighborhood_id', null))
+                            ->afterStateUpdated(fn (Set $set) => $set('neighborhood_id', null))
                             ->label(__('City'))
                             ->translateLabel()
                             ->required(),
 
                         Forms\Components\Select::make('neighborhood_id')
-                            ->options(fn(Get $get): Collection => Neighborhood::query()->where('city_id', $get('city_id'))->pluck('name', 'id'))
+                            ->options(fn (Get $get): Collection => Neighborhood::query()->where('city_id', $get('city_id'))->pluck('name', 'id'))
                             ->searchable()
                             ->preload()
                             ->label(__('Neighborhood'))
@@ -95,7 +98,7 @@ class UserResource extends Resource
                             ->translateLabel()
                             ->columnSpanFull()
                             ->required(),
-                    ])
+                    ]),
             ]);
     }
 
@@ -116,6 +119,15 @@ class UserResource extends Resource
                     ->translateLabel()
                     ->sortable()
                     ->searchable(),
+                Tables\Columns\TextColumn::make('roles.name')
+                    ->label('Rol')
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state): string => match ($state) {
+                        'admin' => 'Administrador',
+                        'veterinarian' => 'Veterinario',
+                        'assistant' => 'Asistente',
+                        default => $state ?? '—',
+                    }),
                 Tables\Columns\TextColumn::make('created_at')
                     ->translateLabel()
                     ->dateTime('d/m/Y H:i')
@@ -128,7 +140,14 @@ class UserResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\SelectFilter::make('roles')
+                    ->relationship('roles', 'name')
+                    ->label('Rol')
+                    ->options([
+                        'admin' => 'Administrador',
+                        'veterinarian' => 'Veterinario',
+                        'assistant' => 'Asistente',
+                    ]),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
@@ -151,12 +170,12 @@ class UserResource extends Resource
         return auth()->user()?->hasRole('admin') ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasRole('admin') ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasRole('admin') ?? false;
     }

--- a/app/Filament/Resources/VaccinationResource.php
+++ b/app/Filament/Resources/VaccinationResource.php
@@ -9,15 +9,16 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class VaccinationResource extends Resource
 {
     protected static ?string $model = Vaccination::class;
 
-    protected static ?string $navigationGroup = 'Procedures';
+    protected static ?string $navigationGroup = 'Historial clínico';
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
 
     protected static ?string $modelLabel = 'vacunación';
 
@@ -164,7 +165,12 @@ class VaccinationResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Tables\Filters\Filter::make('overdue')
+                    ->label('Vencidas')
+                    ->query(fn (Builder $query) => $query->where('next_application', '<', now())),
+                Tables\Filters\Filter::make('upcoming')
+                    ->label('Próximas (7 días)')
+                    ->query(fn (Builder $query) => $query->whereBetween('next_application', [now(), now()->addDays(7)])),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/app/Filament/Resources/VaccinationResource.php
+++ b/app/Filament/Resources/VaccinationResource.php
@@ -3,25 +3,24 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\VaccinationResource\Pages;
-use App\Filament\Resources\VaccinationResource\RelationManagers;
 use App\Models\Vaccination;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
-use App\Filament\Exports\VaccinationExporter;
-use Filament\Tables\Actions\ExportAction;
-
+use Illuminate\Database\Eloquent\Model;
 
 class VaccinationResource extends Resource
 {
     protected static ?string $model = Vaccination::class;
+
     protected static ?string $navigationGroup = 'Procedures';
+
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
     protected static ?string $modelLabel = 'vacunación';
+
     protected static ?string $pluralModelLabel = 'vacunaciones';
 
     public static function form(Form $form): Form
@@ -109,7 +108,7 @@ class VaccinationResource extends Resource
                     ->required(),
                 Forms\Components\Textarea::make('observation')
                     ->translateLabel()
-                    ->columnSpanFull()
+                    ->columnSpanFull(),
             ]);
     }
 
@@ -188,12 +187,12 @@ class VaccinationResource extends Resource
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canEdit(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }
 
-    public static function canDelete(\Illuminate\Database\Eloquent\Model $record): bool
+    public static function canDelete(Model $record): bool
     {
         return auth()->user()?->hasAnyRole(['admin', 'veterinarian']) ?? false;
     }

--- a/app/Filament/Widgets/PetSpeciesOverview.php
+++ b/app/Filament/Widgets/PetSpeciesOverview.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Enums\PetSpecies;
 use App\Models\Pet;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -11,9 +12,15 @@ class PetSpeciesOverview extends BaseWidget
     protected function getStats(): array
     {
         return [
-            Stat::make('Perros', Pet::query()->where('species', 'Perro')->count()),
-            Stat::make('Gatos', Pet::query()->where('species', 'Gato')->count()),
-            Stat::make('Total', Pet::all()->count()),
+            Stat::make('Caninos', Pet::query()->where('species', PetSpecies::Canino)->count())
+                ->icon('heroicon-o-identification')
+                ->color('info'),
+            Stat::make('Felinos', Pet::query()->where('species', PetSpecies::Felino)->count())
+                ->icon('heroicon-o-identification')
+                ->color('warning'),
+            Stat::make('Total', Pet::query()->count())
+                ->icon('heroicon-o-rectangle-stack')
+                ->color('success'),
         ];
     }
 }

--- a/app/Filament/Widgets/RecentConsultationsWidget.php
+++ b/app/Filament/Widgets/RecentConsultationsWidget.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Consultation;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class RecentConsultationsWidget extends BaseWidget
+{
+    protected static ?int $sort = 2;
+
+    protected int|string|array $columnSpan = 'full';
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasAnyRole(['admin', 'veterinarian', 'assistant']) ?? false;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->heading('Consultas recientes')
+            ->query(
+                Consultation::query()
+                    ->with(['pet', 'user'])
+                    ->latest()
+                    ->limit(5)
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('pet.name')
+                    ->label('Mascota'),
+                Tables\Columns\TextColumn::make('diagnosis')
+                    ->label('Diagnóstico')
+                    ->limit(60),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Veterinario'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Fecha')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Filament/Widgets/UpcomingVaccinationsWidget.php
+++ b/app/Filament/Widgets/UpcomingVaccinationsWidget.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Vaccination;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Support\Carbon;
+
+class UpcomingVaccinationsWidget extends BaseWidget
+{
+    protected static ?int $sort = 1;
+
+    protected int|string|array $columnSpan = 'full';
+
+    public static function canView(): bool
+    {
+        return auth()->user()?->hasAnyRole(['admin', 'veterinarian', 'assistant']) ?? false;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->heading('Vacunas próximas a vencer')
+            ->query(
+                Vaccination::query()
+                    ->with(['pet', 'pet.owner'])
+                    ->where('next_application', '<', now()->addDays(7))
+                    ->orderBy('next_application')
+            )
+            ->columns([
+                Tables\Columns\TextColumn::make('pet.name')
+                    ->label('Mascota')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('pet.owner.full_name')
+                    ->label('Propietario'),
+                Tables\Columns\TextColumn::make('vaccine')
+                    ->label('Vacuna'),
+                Tables\Columns\TextColumn::make('next_application')
+                    ->label('Próxima aplicación')
+                    ->date('d/m/Y')
+                    ->color(fn ($state) => match (true) {
+                        Carbon::parse($state)->isPast() => 'danger',
+                        Carbon::parse($state)->lte(now()->addDays(3)) => 'warning',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+            ])
+            ->paginated([5, 10, 25]);
+    }
+}

--- a/app/Models/Pet.php
+++ b/app/Models/Pet.php
@@ -2,6 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\PetGender;
+use App\Enums\PetReproductionStatus;
+use App\Enums\PetSize;
+use App\Enums\PetSpecies;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -33,11 +38,38 @@ class Pet extends Model
         'user_id', // ID del veterinario que registró la mascota
     ];
 
+    protected function casts(): array
+    {
+        return [
+            'species' => PetSpecies::class,
+            'gender' => PetGender::class,
+            'size' => PetSize::class,
+            'reproduction' => PetReproductionStatus::class,
+            'birthdate' => 'date',
+        ];
+    }
+
+    /**
+     * Edad de la mascota en años (o meses si es menor a un año).
+     */
+    protected function age(): Attribute
+    {
+        return Attribute::make(get: function () {
+            $years = (int) $this->birthdate->diffInYears(now());
+
+            if ($years > 0) {
+                return "{$years} ".($years === 1 ? 'año' : 'años');
+            }
+
+            $months = (int) $this->birthdate->diffInMonths(now());
+
+            return "{$months} ".($months === 1 ? 'mes' : 'meses');
+        });
+    }
+
     /**
      * Una mascota pertenece a un dueño.
      * Esta relación define que cada mascota está asociada con un dueño específico.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function owner(): BelongsTo
     {
@@ -47,8 +79,6 @@ class Pet extends Model
     /**
      * Una mascota pertenece a un usuario (veterinario).
      * Esta relación define que cada mascota está asociada con un veterinario específico.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user(): BelongsTo
     {
@@ -58,8 +88,6 @@ class Pet extends Model
     /**
      * Una mascota tiene muchas vacunaciones.
      * Esta relación define que una mascota puede tener múltiples registros de vacunación asociados.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function vaccinations(): HasMany
     {
@@ -69,8 +97,6 @@ class Pet extends Model
     /**
      * Una mascota tiene muchas consultas.
      * Esta relación define que una mascota puede tener múltiples consultas médicas asociadas.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function consultations(): HasMany
     {
@@ -80,20 +106,16 @@ class Pet extends Model
     /**
      * Una mascota tiene muchas cirugías.
      * Esta relación define que una mascota puede tener múltiples cirugías asociadas.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function surgeries(): HasMany
     {
         return $this->hasMany(Surgery::class);
+    }
 
-/**
+    /**
      * Una mascota tiene muchos exámenes.
      * Esta relación define que una mascota puede tener múltiples exámenes de laboratorio asociados.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
-     */    }
-
+     */
     public function tests(): HasMany
     {
         return $this->hasMany(Test::class);

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -25,11 +25,16 @@ class Test extends Model
         'user_id', // ID del veterinario que realizó el examen
     ];
 
+    protected function casts(): array
+    {
+        return [
+            'result' => 'array',
+        ];
+    }
+
     /**
      * Un examen pertenece a una mascota.
      * Esta relación define que cada examen está asociado con una mascota específica.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function pet(): BelongsTo
     {
@@ -39,8 +44,6 @@ class Test extends Model
     /**
      * Un examen pertenece a un usuario (veterinario).
      * Esta relación define que cada examen está asociado con un veterinario específico.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user(): BelongsTo
     {

--- a/app/Notifications/VaccinationNotification.php
+++ b/app/Notifications/VaccinationNotification.php
@@ -2,8 +2,9 @@
 
 namespace App\Notifications;
 
+use App\Filament\Resources\PetResource;
+use App\Settings\ClinicSettings;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
@@ -36,12 +37,14 @@ class VaccinationNotification extends Notification
      */
     public function toMail(object $notifiable): MailMessage
     {
+        $clinic = app(ClinicSettings::class);
+
         return (new MailMessage)
-            ->greeting('¡Hola, ' . $this->vaccination->pet->owner->first_name . '!')
+            ->greeting('¡Hola, '.$this->vaccination->pet->owner->first_name.'!')
             ->subject(__('Recordatorio de vacunación para tu mascota.'))
-            ->line('La vacuna de tu mascota ' . $this->vaccination->pet->name . ' está por vencer el '. $this->vaccination->next_application)
-            ->action('Ver detalles', url('http://127.0.0.1:8000/admin/pets/2/edit'))
-            ->line('¡Gracias por usar nuestra aplicación!');
+            ->line('La vacuna de tu mascota '.$this->vaccination->pet->name.' está por vencer el '.$this->vaccination->next_application)
+            ->action('Ver detalles', PetResource::getUrl('edit', ['record' => $this->vaccination->pet_id]))
+            ->salutation('Saludos, '.$clinic->name);
     }
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Settings\ClinicSettings;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -16,12 +17,18 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class AdminPanelProvider extends PanelProvider
 {
     public function panel(Panel $panel): Panel
     {
+        // La tabla de settings puede no existir aún (instalación nueva antes de migrar),
+        // así que el panel cae a los valores por defecto en ese caso.
+        $settings = Schema::hasTable('settings') ? app(ClinicSettings::class) : null;
+
         return $panel
             ->default()
             ->id('admin')
@@ -31,8 +38,11 @@ class AdminPanelProvider extends PanelProvider
             ->spa()
             ->profile(isSimple: false)
             ->sidebarCollapsibleOnDesktop()
+            ->brandName($settings?->name ?? config('app.name'))
+            ->brandLogo($settings?->logo ? Storage::url($settings->logo) : null)
+            ->favicon($settings?->favicon ? Storage::url($settings->favicon) : null)
             ->colors([
-                'primary' => Color::Amber,
+                'primary' => $settings?->primary_color ? Color::hex($settings->primary_color) : Color::Amber,
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')

--- a/app/Services/AIDiagnosticService.php
+++ b/app/Services/AIDiagnosticService.php
@@ -3,7 +3,6 @@
 namespace App\Services;
 
 use App\Models\Pet;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
@@ -11,10 +10,12 @@ class AIDiagnosticService
 {
     public function suggest(Pet $pet, string $anamnesis): array
     {
-        $age = $this->formatAge($pet->birthdate);
-        $userPrompt = "Paciente: {$pet->species} | Raza: {$pet->breed} | Edad: {$age} | Peso: {$pet->weight}kg\n"
-            . "Género: {$pet->gender} | Reproducción: {$pet->reproduction}\n\n"
-            . "Anamnesis:\n{$anamnesis}";
+        $species = $pet->species->getLabel();
+        $gender = $pet->gender->getLabel();
+        $reproduction = $pet->reproduction->getLabel();
+        $userPrompt = "Paciente: {$species} | Raza: {$pet->breed} | Edad: {$pet->age} | Peso: {$pet->weight}kg\n"
+            ."Género: {$gender} | Reproducción: {$reproduction}\n\n"
+            ."Anamnesis:\n{$anamnesis}";
 
         $response = Http::withHeaders([
             'x-api-key' => config('services.anthropic.key'),
@@ -29,7 +30,7 @@ class AIDiagnosticService
         ]);
 
         if ($response->failed()) {
-            throw new RuntimeException('Error al conectar con la API de IA: ' . $response->status());
+            throw new RuntimeException('Error al conectar con la API de IA: '.$response->status());
         }
 
         $content = $response->json('content.0.text') ?? '';
@@ -38,23 +39,10 @@ class AIDiagnosticService
 
         $result = json_decode($content, true);
 
-        if (!isset($result['diagnosis'], $result['treatment'])) {
+        if (! isset($result['diagnosis'], $result['treatment'])) {
             throw new RuntimeException('La respuesta de la IA no tiene el formato esperado.');
         }
 
         return $result;
-    }
-
-    private function formatAge(mixed $birthdate): string
-    {
-        $birth = Carbon::parse($birthdate);
-        $years = $birth->diffInYears(now());
-
-        if ($years > 0) {
-            return "{$years} " . ($years === 1 ? 'año' : 'años');
-        }
-
-        $months = $birth->diffInMonths(now());
-        return "{$months} " . ($months === 1 ? 'mes' : 'meses');
     }
 }

--- a/app/Settings/ClinicSettings.php
+++ b/app/Settings/ClinicSettings.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class ClinicSettings extends Settings
+{
+    public string $name;
+
+    public ?string $logo;
+
+    public ?string $favicon;
+
+    public ?string $primary_color;
+
+    public ?string $address;
+
+    public ?string $phone;
+
+    public ?string $email;
+
+    public ?string $business_hours;
+
+    public ?string $ruc;
+
+    public ?string $razon_social;
+
+    public ?string $facebook;
+
+    public ?string $instagram;
+
+    public ?string $website;
+
+    public static function group(): string
+    {
+        return 'clinic';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "laravel/tinker": "^2.9",
         "league/flysystem-aws-s3-v3": "3.0",
         "resend/resend-laravel": "^1.4",
-        "spatie/laravel-permission": "^6.25"
+        "spatie/laravel-permission": "^6.25",
+        "spatie/laravel-settings": "*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93ea07e2158fe9175b254dd1092c33d9",
+    "content-hash": "5f93e8569bf3ead3b9f1405d127539ca",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4337,6 +4337,117 @@
             "time": "2025-09-03T16:03:54+00:00"
         },
         {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.5",
             "source": {
@@ -4410,6 +4521,53 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "psr/cache",
@@ -5697,6 +5855,152 @@
                 }
             ],
             "time": "2026-03-17T22:46:46+00:00"
+        },
+        {
+            "name": "spatie/laravel-settings",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-settings.git",
+                "reference": "6c1351cf57c4ae96cd2313ae395c6d367dfeee01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-settings/zipball/6c1351cf57c4ae96cd2313ae395c6d367dfeee01",
+                "reference": "6c1351cf57c4ae96cd2313ae395c6d367dfeee01",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "phpdocumentor/type-resolver": "^1.5|^2.0",
+                "spatie/temporary-directory": "^1.3|^2.0"
+            },
+            "require-dev": {
+                "ext-redis": "*",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "spatie/laravel-data": "^2.0.0|^4.0.0",
+                "spatie/pest-plugin-snapshots": "^2.0",
+                "spatie/phpunit-snapshot-assertions": "^4.2|^5.0",
+                "spatie/ray": "^1.36"
+            },
+            "suggest": {
+                "spatie/data-transfer-object": "Allows for DTO casting to settings. (deprecated)"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\LaravelSettings\\LaravelSettingsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelSettings\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Van Assche",
+                    "email": "ruben@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Store your application settings",
+            "homepage": "https://github.com/spatie/laravel-settings",
+            "keywords": [
+                "laravel-settings",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-settings/issues",
+                "source": "https://github.com/spatie/laravel-settings/tree/3.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-26T13:18:06+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/32cbb9645b28839cf4f476708e99a2c70e6802c9",
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-22T07:55:44+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,0 +1,100 @@
+<?php
+
+return [
+
+    /*
+     * Each settings class used in your application must be registered, you can
+     * put them (manually) here.
+     */
+    'settings' => [
+
+    ],
+
+    /*
+     * The path where the settings classes will be created.
+     */
+    'setting_class_path' => app_path('Settings'),
+
+    /*
+     * In these directories settings migrations will be stored and ran when migrating. A settings
+     * migration created via the make:settings-migration command will be stored in the first path or
+     * a custom defined path when running the command.
+     */
+    'migrations_paths' => [
+        database_path('settings'),
+    ],
+
+    /*
+     * When no repository was set for a settings class the following repository
+     * will be used for loading and saving settings.
+     */
+    'default_repository' => 'database',
+
+    /*
+     * Settings will be stored and loaded from these repositories.
+     */
+    'repositories' => [
+        'database' => [
+            'type' => Spatie\LaravelSettings\SettingsRepositories\DatabaseSettingsRepository::class,
+            'model' => null,
+            'table' => null,
+            'connection' => null,
+        ],
+        'redis' => [
+            'type' => Spatie\LaravelSettings\SettingsRepositories\RedisSettingsRepository::class,
+            'connection' => null,
+            'prefix' => null,
+        ],
+    ],
+
+    /*
+     * The encoder and decoder will determine how settings are stored and
+     * retrieved in the database. By default, `json_encode` and `json_decode`
+     * are used.
+     */
+    'encoder' => null,
+    'decoder' => null,
+
+    /*
+     * The contents of settings classes can be cached through your application,
+     * settings will be stored within a provided Laravel store and can have an
+     * additional prefix.
+     */
+    'cache' => [
+        'enabled' => (bool)env('SETTINGS_CACHE_ENABLED', false),
+        'store' => null,
+        'prefix' => null,
+        'ttl' => null,
+
+        /*
+         * When enabled, uses Laravel's memoized cache driver (requires Laravel 12.9+)
+         * to keep resolved values in memory during a single request.
+         */
+        'memo' => env('SETTINGS_CACHE_MEMO', false),
+    ],
+
+    /*
+     * These global casts will be automatically used whenever a property within
+     * your settings class isn't a default PHP type.
+     */
+    'global_casts' => [
+        DateTimeInterface::class => Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast::class,
+        DateTimeZone::class => Spatie\LaravelSettings\SettingsCasts\DateTimeZoneCast::class,
+//        Spatie\DataTransferObject\DataTransferObject::class => Spatie\LaravelSettings\SettingsCasts\DtoCast::class,
+        Spatie\LaravelData\Data::class => Spatie\LaravelSettings\SettingsCasts\DataCast::class,
+    ],
+
+    /*
+     * The package will look for settings in these paths and automatically
+     * register them.
+     */
+    'auto_discover_settings' => [
+        app_path('Settings'),
+    ],
+
+    /*
+     * Automatically discovered settings classes can be cached, so they don't
+     * need to be searched each time the application boots up.
+     */
+    'discovered_settings_cache_path' => base_path('bootstrap/cache'),
+];

--- a/database/migrations/2022_12_14_083707_create_settings_table.php
+++ b/database/migrations/2022_12_14_083707_create_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(config('settings.repositories.database.table') ?? 'settings', function (Blueprint $table): void {
+            $table->id();
+
+            $table->string('group');
+            $table->string('name');
+            $table->boolean('locked')->default(false);
+            $table->json('payload');
+
+            $table->timestamps();
+
+            $table->unique(['group', 'name']);
+        });
+    }
+};

--- a/database/migrations/2026_07_29_000000_change_result_column_on_tests_table.php
+++ b/database/migrations/2026_07_29_000000_change_result_column_on_tests_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tests', function (Blueprint $table) {
+            $table->json('result')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tests', function (Blueprint $table) {
+            $table->string('result')->nullable(false)->change();
+        });
+    }
+};

--- a/database/seeders/ProductionSeeder.php
+++ b/database/seeders/ProductionSeeder.php
@@ -19,17 +19,18 @@ class ProductionSeeder extends Seeder
 
         if (empty($email)) {
             $this->command->warn('ADMIN_EMAIL no está configurado; se omite la creación del usuario admin.');
+
             return;
         }
 
+        $password = Str::password(16);
+
         $user = User::firstOrCreate(
             ['email' => $email],
-            ['name' => config('app.admin_name'), 'email_verified_at' => now()]
+            ['name' => config('app.admin_name'), 'email_verified_at' => now(), 'password' => $password]
         );
 
         if ($user->wasRecentlyCreated) {
-            $password = Str::password(16);
-            $user->forceFill(['password' => $password])->save();
             $this->command->warn("Usuario admin creado ({$email}). Password generada: {$password} — guardala ya que no se vuelve a mostrar.");
         } else {
             $this->command->info("Usuario admin ya existía ({$email}), no se modifica la password.");

--- a/database/seeders/TestSeeder.php
+++ b/database/seeders/TestSeeder.php
@@ -14,84 +14,75 @@ class TestSeeder extends Seeder
         $pets = Pet::all();
         $vets = User::all();
 
-        // [pet_index, fecha, tipo, resultado, observación]
+        // [pet_index, fecha, tipo (categoría), observación (incluye el examen específico y el resultado)]
         $tests = [
             [
                 1,
                 '2024-02-20',
-                'Hemograma completo',
-                'Eritrocitos: 7.2M/µL | Hb: 14.5g/dL | Hematocrito: 44% | Leucocitos: 8.200/µL (Neutrófilos 65%, Linfocitos 28%, Monocitos 7%) | Plaquetas: 320.000/µL',
-                'Valores dentro del rango normal para la especie y edad.',
+                'Hematología',
+                'Hemograma completo. Eritrocitos: 7.2M/µL | Hb: 14.5g/dL | Hematocrito: 44% | Leucocitos: 8.200/µL (Neutrófilos 65%, Linfocitos 28%, Monocitos 7%) | Plaquetas: 320.000/µL. Valores dentro del rango normal para la especie y edad.',
             ],
             [
                 1,
                 '2024-02-20',
-                'Bioquímica sérica',
-                'Glucosa: 92mg/dL | Urea: 32mg/dL | Creatinina: 0.9mg/dL | ALT: 38U/L | AST: 29U/L | Proteínas totales: 7.1g/dL | Albumina: 3.4g/dL',
-                'Función renal y hepática normal. Sin alteraciones metabólicas.',
+                'Bioquímica',
+                'Bioquímica sérica. Glucosa: 92mg/dL | Urea: 32mg/dL | Creatinina: 0.9mg/dL | ALT: 38U/L | AST: 29U/L | Proteínas totales: 7.1g/dL | Albumina: 3.4g/dL. Función renal y hepática normal. Sin alteraciones metabólicas.',
             ],
             [
                 7,
                 '2024-04-15',
-                'Hemograma completo',
-                'Eritrocitos: 4.1M/µL | Hb: 9.2g/dL | Hematocrito: 28% | Leucocitos: 5.800/µL | Plaquetas: 89.000/µL',
-                'Anemia moderada normocítica normocrómica. Trombocitopenia. Compatible con Ehrlichiosis canina.',
+                'Hematología',
+                'Hemograma completo. Eritrocitos: 4.1M/µL | Hb: 9.2g/dL | Hematocrito: 28% | Leucocitos: 5.800/µL | Plaquetas: 89.000/µL. Anemia moderada normocítica normocrómica. Trombocitopenia. Compatible con Ehrlichiosis canina.',
             ],
             [
                 7,
                 '2024-04-15',
-                'ELISA Ehrlichia canis',
-                'Positivo (++). Título de anticuerpos elevado.',
-                'Confirma diagnóstico de Ehrlichiosis. Iniciar doxiciclina 10mg/kg c/24hs por 28 días. Control de hemograma a los 14 días.',
+                'Inmunología',
+                'ELISA Ehrlichia canis. Positivo (++). Título de anticuerpos elevado. Confirma diagnóstico de Ehrlichiosis. Iniciar doxiciclina 10mg/kg c/24hs por 28 días. Control de hemograma a los 14 días.',
             ],
             [
                 4,
                 '2024-01-23',
-                'Radiografía de tórax',
-                'Sin evidencia de fracturas costales. Parénquima pulmonar normal. Silueta cardíaca conservada.',
-                'Solicitada tras trauma por caída. Descarta lesiones intratorácicas.',
+                'Otros',
+                'Radiografía de tórax. Sin evidencia de fracturas costales. Parénquima pulmonar normal. Silueta cardíaca conservada. Solicitada tras trauma por caída. Descarta lesiones intratorácicas.',
             ],
             [
                 1,
                 '2024-03-01',
-                'Raspado cutáneo',
-                'Presencia de ácaros Sarcoptes scabiei en muestra analizada. Moderada cantidad.',
-                'Confirma diagnóstico de sarna sarcóptica. Continuar protocolo de ivermectina. Tratar todos los animales en contacto.',
+                'Parasitología',
+                'Raspado cutáneo. Presencia de ácaros Sarcoptes scabiei en muestra analizada. Moderada cantidad. Confirma diagnóstico de sarna sarcóptica. Continuar protocolo de ivermectina. Tratar todos los animales en contacto.',
             ],
             [
                 10,
                 '2024-03-26',
-                'Perfil bioquímico hepático',
-                'ALT: 189U/L (elevada) | AST: 145U/L (elevada) | Bilirrubina total: 2.8mg/dL | Proteínas totales: 5.2g/dL | Albumina: 2.1g/dL',
-                'Compatible con lipidosis hepática felina. Iniciar tratamiento de soporte hepático de inmediato.',
+                'Bioquímica',
+                'Perfil bioquímico hepático. ALT: 189U/L (elevada) | AST: 145U/L (elevada) | Bilirrubina total: 2.8mg/dL | Proteínas totales: 5.2g/dL | Albumina: 2.1g/dL. Compatible con lipidosis hepática felina. Iniciar tratamiento de soporte hepático de inmediato.',
             ],
             [
                 12,
                 '2024-02-21',
-                'Urinálisis y sedimento',
-                'pH: 7.5 | Densidad: 1.038 | Proteínas: + | Cristales de estruvita: +++ | Leucocitos: 8-10/campo',
-                'Cristaluria severa por estruvita. Cistitis secundaria. Confirma necesidad de dieta acidificante y aumento de ingesta hídrica.',
+                'Uroanálisis',
+                'Urinálisis y sedimento. pH: 7.5 | Densidad: 1.038 | Proteínas: + | Cristales de estruvita: +++ | Leucocitos: 8-10/campo. Cristaluria severa por estruvita. Cistitis secundaria. Confirma necesidad de dieta acidificante y aumento de ingesta hídrica.',
             ],
             [
                 6,
                 '2024-03-19',
-                'Test rápido Parvovirus',
-                'Positivo.',
-                'Confirma parvovirus canino. Se mantiene hospitalización y tratamiento de soporte. Pronóstico reservado.',
+                'Prueba Rápida',
+                'Test rápido Parvovirus. Positivo. Confirma parvovirus canino. Se mantiene hospitalización y tratamiento de soporte. Pronóstico reservado.',
             ],
         ];
 
-        foreach ($tests as [$petIdx, $date, $type, $result, $observation]) {
+        foreach ($tests as [$petIdx, $date, $type, $observation]) {
             $pet = $pets[$petIdx % $pets->count()];
             $vet = $vets->random();
 
             Test::create([
-                'date'        => $date,
-                'type'        => $type,
-                'result'      => $result,
+                'date' => $date,
+                'type' => $type,
+                'result' => null,
                 'observation' => $observation,
-                'pet_id'      => $pet->id,
-                'user_id'     => $vet->id,
+                'pet_id' => $pet->id,
+                'user_id' => $vet->id,
             ]);
         }
     }

--- a/database/settings/2026_07_28_235148_create_clinic_settings.php
+++ b/database/settings/2026_07_28_235148_create_clinic_settings.php
@@ -1,0 +1,23 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('clinic.name', config('app.name'));
+        $this->migrator->add('clinic.logo', null);
+        $this->migrator->add('clinic.favicon', null);
+        $this->migrator->add('clinic.primary_color', null);
+        $this->migrator->add('clinic.address', null);
+        $this->migrator->add('clinic.phone', null);
+        $this->migrator->add('clinic.email', null);
+        $this->migrator->add('clinic.business_hours', null);
+        $this->migrator->add('clinic.ruc', null);
+        $this->migrator->add('clinic.razon_social', null);
+        $this->migrator->add('clinic.facebook', null);
+        $this->migrator->add('clinic.instagram', null);
+        $this->migrator->add('clinic.website', null);
+    }
+};

--- a/lang/es.json
+++ b/lang/es.json
@@ -102,6 +102,7 @@
     "Fur": "Pelaje",
     "Gateway Timeout": "Tiempo de espera de puerta de enlace",
     "Gender": "Género",
+    "General information": "Información general",
     "Giant": "Gigante",
     "Go Home": "Ir a inicio",
     "Go to page :page": "Ir a la página :page",
@@ -345,6 +346,9 @@
     "Thoracotomy": "Toracotomía",
     "Intestinal Resection": "Resección Intestinal",
     "Perianal Gland Surgery": "Cirugía de Glándulas Perianales",
+    "Wound Suture": "Sutura de herida",
+    "Dental Extraction": "Extracción dental",
+    "Urethral Unblocking": "Desobstrucción uretral",
 
     "Hematology": "Hematología",
     "Biochemistry": "Bioquímica",

--- a/resources/views/filament/pages/clinic-settings-page.blade.php
+++ b/resources/views/filament/pages/clinic-settings-page.blade.php
@@ -1,0 +1,11 @@
+<x-filament-panels::page>
+    <form wire:submit="save">
+        {{ $this->form }}
+
+        <div class="mt-6">
+            <x-filament::button type="submit">
+                Guardar
+            </x-filament::button>
+        </div>
+    </form>
+</x-filament-panels::page>

--- a/resources/views/pdf/vaccine-card.blade.php
+++ b/resources/views/pdf/vaccine-card.blade.php
@@ -30,9 +30,18 @@
 
 <body>
     <div class="header">
-        <h2>{{ config('app.name') }}</h2>
+        @if($clinic->logo)
+            <img src="{{ Illuminate\Support\Facades\Storage::path($clinic->logo) }}" alt="{{ $clinic->name }}" style="max-height: 80px;">
+        @endif
+        <h2>{{ $clinic->name }}</h2>
+        @if($clinic->address || $clinic->phone)
+            <p>{{ $clinic->address }}{{ $clinic->address && $clinic->phone ? ' | ' : '' }}{{ $clinic->phone }}</p>
+        @endif
+        @if($clinic->ruc)
+            <p>RUC: {{ $clinic->ruc }}</p>
+        @endif
         <h3>Carnet de Vacunación</h3>
-        <p>Mascota: {{ $pet->name }} | Especie: {{ $pet->species }} | Raza: {{ $pet->breed }} | Fecha de nacimiento: {{ \Carbon\Carbon::parse($pet->birthdate)->format('d/m/Y') }}</p>
+        <p>Mascota: {{ $pet->name }} | Especie: {{ $pet->species->getLabel() }} | Raza: {{ $pet->breed }} | Fecha de nacimiento: {{ $pet->birthdate->format('d/m/Y') }}</p>
         <p>Responsable: {{ $pet->owner->full_name }} | Telefono: {{ $pet->owner->phone }}</p>
     </div>
 


### PR DESCRIPTION
Adds spatie/laravel-settings-backed clinic configuration (name, logo,
favicon, primary color, contact, legal, and social data) with a Filament
settings page, wiring it into panel branding, the vaccination-card PDF,
and the vaccination reminder email.

Converts Pet's species/gender/size/reproduction into native enums
implementing Filament's HasColor/HasIcon/HasLabel, replacing duplicated
hardcoded option arrays (PetResource and Owner's nested Pet relation
manager) and enabling colored badges, table filters, and a distinct
navigation icon on the Pet resource. Adds a computed age accessor on
Pet (single source of truth, replacing AIDiagnosticService's private
formatAge) and a read-only Pet view page with a matching infolist.
Adds date-range/overdue/upcoming filters to Pet's medical record
relation managers.

Fixes: PetSpeciesOverview dashboard widget comparing against species
values that never matched real data; VaccinationNotification's
hardcoded localhost URL and static pet ID; dead VaccinationExporter/
ExportAction imports; missing user_id on consultations created from
the standalone Consultation page; a fractional age bug from Carbon 3's
diffInYears/diffInMonths now returning floats; and a NOT NULL
constraint violation in ProductionSeeder's admin user creation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011cNncT3PVH9fyfavPysZi9