### PR TITLE
Enhance AI diagnostic suggestions with urgency detection and audit trail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,7 @@ PUSHER_APP_CLUSTER=mt1
 VITE_API_BASE_URL=${APP_URL}/api
 
 ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-opus-4-8
 
 ADMIN_NAME="Dr. Roberto Benítez"
 ADMIN_EMAIL=admin@mbopivet.com.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,9 @@ El widget `PetSpeciesOverview` muestra estadísticas de especies en el dashboard
 
 ### Diagnóstico asistido por IA
 
-`app/Services/AIDiagnosticService.php` encapsula la integración con la API de Claude (Anthropic). El método `suggest(Pet $pet, string $anamnesis): array` construye un prompt con los datos clínicos de la mascota (especie, raza, edad, peso, género, reproducción) y la anamnesis del veterinario, llama a `claude-opus-4-7` y retorna `['diagnosis' => '...', 'treatment' => '...']` en JSON.
+`app/Services/AIDiagnosticService.php` encapsula la integración con la API de Claude (Anthropic). El método `suggest(Pet $pet, string $anamnesis): array` construye un prompt con los datos clínicos de la mascota (especie, raza, edad, peso, género, reproducción) y la anamnesis del veterinario, llama al modelo configurado en `config('services.anthropic.model')` (env `ANTHROPIC_MODEL`, default `claude-opus-4-8`) y retorna `['diagnosis' => '...', 'treatment' => '...']` en JSON.
 
-El botón **"Asistir con IA"** aparece en el formulario de consulta dentro de `ConsultationsRelationManager` (flujo principal) y en `ConsultationResource` (solo en edición, cuando ya existe el registro con pet asociado). Al presionarlo, pre-rellena los campos Diagnóstico y Tratamiento — el veterinario puede editar antes de guardar.
+El botón **"Asistir con IA"** aparece en el formulario de consulta tanto en `ConsultationsRelationManager` como en `ConsultationResource`, en creación y edición. Al presionarlo, pre-rellena los campos Diagnóstico y Tratamiento — el veterinario puede editar antes de guardar. Si esos campos ya tienen contenido, se pide confirmación antes de sobrescribirlos.
 
 Requiere `ANTHROPIC_API_KEY` en `.env`. La key se obtiene en [console.anthropic.com](https://console.anthropic.com).
 

--- a/app/Enums/AiUrgencyLevel.php
+++ b/app/Enums/AiUrgencyLevel.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Nivel de urgencia clínica que la IA detecta a partir de la anamnesis. Los backing
+ * values están en español (no en inglés, a diferencia de otros enums del proyecto)
+ * porque deben coincidir exactamente con lo que el prompt le pide a la IA en su
+ * respuesta JSON.
+ */
+enum AiUrgencyLevel: string implements HasColor, HasLabel
+{
+    case Baja = 'baja';
+    case Media = 'media';
+    case Alta = 'alta';
+    case Emergencia = 'emergencia';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Baja => 'Baja',
+            self::Media => 'Media',
+            self::Alta => 'Alta',
+            self::Emergencia => 'Emergencia',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Baja => 'success',
+            self::Media => 'warning',
+            self::Alta, self::Emergencia => 'danger',
+        };
+    }
+}

--- a/app/Enums/AiUsageStatus.php
+++ b/app/Enums/AiUsageStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum AiUsageStatus: string implements HasColor, HasLabel
+{
+    case Manual = 'Manual';
+    case UsedAsIs = 'UsedAsIs';
+    case Edited = 'Edited';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Manual => 'Manual',
+            self::UsedAsIs => 'Usado tal cual',
+            self::Edited => 'Editado',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Manual => 'gray',
+            self::UsedAsIs => 'info',
+            self::Edited => 'success',
+        };
+    }
+}

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -9,6 +9,7 @@ use App\Models\Consultation;
 use App\Models\Pet;
 use App\Services\AIDiagnosticService;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
@@ -54,126 +55,137 @@ class ConsultationResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\Select::make('pet_id')
-                    ->label('Mascota')
-                    ->relationship('pet', 'name', modifyQueryUsing: fn (Builder $query, ?Consultation $record) => $query->where(
-                        fn (Builder $q) => $q->where('active', true)
-                            ->when($record?->pet_id, fn (Builder $q, $petId) => $q->orWhere('id', $petId))
-                    ))
-                    ->searchable(['name', 'id'])
-                    ->preload()
-                    ->live()
-                    ->required(),
-                Forms\Components\DatePicker::make('consultation_date')
-                    ->label('Fecha de consulta')
-                    ->required()
-                    ->native(false)
-                    ->maxDate(now())
-                    ->default(now()),
-                Forms\Components\Textarea::make('anamnesis')
-                    ->label('Anamnesis')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000)
-                    ->required(),
-                Forms\Components\Actions::make([
-                    Forms\Components\Actions\Action::make('aiSuggest')
-                        ->label('Asistir con IA')
-                        ->modalHeading(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Sobrescribir sugerencia existente' : null)
-                        ->modalDescription(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Ya hay contenido en Diagnóstico o Tratamiento. ¿Querés reemplazarlo con la sugerencia de la IA?' : null)
-                        ->modalSubmitActionLabel(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Sí, sobrescribir' : null)
-                        ->requiresConfirmation(fn (Get $get) => static::aiSuggestOverwritesExisting($get))
-                        ->icon('heroicon-o-sparkles')
-                        ->color('info')
-                        ->action(function (Get $get, Set $set) {
-                            try {
-                                $pet = Pet::find($get('pet_id'));
+                Section::make('Información general')
+                    ->columns(2)
+                    ->schema([
+                        Forms\Components\Select::make('pet_id')
+                            ->label('Mascota')
+                            ->relationship('pet', 'name', modifyQueryUsing: fn (Builder $query, ?Consultation $record) => $query->where(
+                                fn (Builder $q) => $q->where('active', true)
+                                    ->when($record?->pet_id, fn (Builder $q, $petId) => $q->orWhere('id', $petId))
+                            ))
+                            ->searchable(['name', 'id'])
+                            ->preload()
+                            ->live()
+                            ->required(),
+                        Forms\Components\DatePicker::make('consultation_date')
+                            ->label('Fecha de consulta')
+                            ->required()
+                            ->native(false)
+                            ->maxDate(now())
+                            ->default(now()),
+                    ]),
+                Section::make('Consulta')
+                    ->schema([
+                        Forms\Components\Textarea::make('anamnesis')
+                            ->label('Anamnesis')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.')
+                            ->required(),
+                        Forms\Components\Actions::make([
+                            Forms\Components\Actions\Action::make('aiSuggest')
+                                ->label('Asistir con IA')
+                                ->modalHeading(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Sobrescribir sugerencia existente' : null)
+                                ->modalDescription(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Ya hay contenido en Diagnóstico o Tratamiento. ¿Querés reemplazarlo con la sugerencia de la IA?' : null)
+                                ->modalSubmitActionLabel(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Sí, sobrescribir' : null)
+                                ->requiresConfirmation(fn (Get $get) => static::aiSuggestOverwritesExisting($get))
+                                ->icon('heroicon-o-sparkles')
+                                ->color('info')
+                                ->action(function (Get $get, Set $set) {
+                                    try {
+                                        $pet = Pet::find($get('pet_id'));
 
-                                if (! $pet) {
-                                    Notification::make()
-                                        ->title('Seleccioná una mascota primero')
-                                        ->warning()
-                                        ->send();
+                                        if (! $pet) {
+                                            Notification::make()
+                                                ->title('Seleccioná una mascota primero')
+                                                ->warning()
+                                                ->send();
 
-                                    return;
-                                }
+                                            return;
+                                        }
 
-                                if (blank($get('anamnesis'))) {
-                                    Notification::make()
-                                        ->title('Completá la anamnesis primero')
-                                        ->body('La IA necesita la anamnesis para poder sugerir un diagnóstico.')
-                                        ->warning()
-                                        ->send();
+                                        if (blank($get('anamnesis'))) {
+                                            Notification::make()
+                                                ->title('Completá la anamnesis primero')
+                                                ->body('La IA necesita la anamnesis para poder sugerir un diagnóstico.')
+                                                ->warning()
+                                                ->send();
 
-                                    return;
-                                }
+                                            return;
+                                        }
 
-                                $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
-                                $set('diagnosis', $result['diagnosis']);
-                                $set('treatment', $result['treatment']);
-                                $set('ai_diagnosis_suggestion', $result['diagnosis']);
-                                $set('ai_treatment_suggestion', $result['treatment']);
-                                $set('ai_urgency', $result['urgency']);
-                                $set('ai_suggested_at', now());
-                                $set('ai_input_tokens', $result['input_tokens']);
-                                $set('ai_output_tokens', $result['output_tokens']);
+                                        $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
+                                        $set('diagnosis', $result['diagnosis']);
+                                        $set('treatment', $result['treatment']);
+                                        $set('ai_diagnosis_suggestion', $result['diagnosis']);
+                                        $set('ai_treatment_suggestion', $result['treatment']);
+                                        $set('ai_urgency', $result['urgency']);
+                                        $set('ai_suggested_at', now());
+                                        $set('ai_input_tokens', $result['input_tokens']);
+                                        $set('ai_output_tokens', $result['output_tokens']);
 
-                                if (in_array($result['urgency'], ['alta', 'emergencia'], true)) {
-                                    Notification::make()
-                                        ->title('Posible urgencia detectada')
-                                        ->body('La IA marcó esta consulta con urgencia "'.$result['urgency'].'". Priorizá la revisión del paciente.')
-                                        ->danger()
-                                        ->send();
-                                }
-                            } catch (\Throwable $e) {
-                                Log::error('Error en sugerencia de IA: '.$e->getMessage());
+                                        if (in_array($result['urgency'], ['alta', 'emergencia'], true)) {
+                                            Notification::make()
+                                                ->title('Posible urgencia detectada')
+                                                ->body('La IA marcó esta consulta con urgencia "'.$result['urgency'].'". Priorizá la revisión del paciente.')
+                                                ->danger()
+                                                ->send();
+                                        }
+                                    } catch (\Throwable $e) {
+                                        Log::error('Error en sugerencia de IA: '.$e->getMessage());
 
-                                Notification::make()
-                                    ->title('Error al generar sugerencia')
-                                    ->body('No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.')
-                                    ->danger()
-                                    ->send();
-                            }
-                        })
-                        ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
-                ])->columnSpanFull(),
-                Forms\Components\Placeholder::make('aiHelp')
-                    ->hiddenLabel()
-                    ->columnSpanFull()
-                    ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
-                    ->content(new HtmlString(
-                        '<p class="text-sm text-gray-500 dark:text-gray-400">'
-                        .'La IA sugiere un diagnóstico y tratamiento en base a la anamnesis. '
-                        .'Revisá siempre la sugerencia antes de guardar — no reemplaza tu criterio profesional.'
-                        .'</p>'
-                        .'<p wire:loading wire:target="mountFormComponentAction" '
-                        .'class="text-sm font-medium text-primary-600 dark:text-primary-400 mt-1">'
-                        .'Generando sugerencia con IA… esto puede tardar unos segundos.'
-                        .'</p>'
-                    )),
-                Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
-                Forms\Components\Hidden::make('ai_treatment_suggestion'),
-                Forms\Components\Hidden::make('ai_urgency'),
-                Forms\Components\Hidden::make('ai_suggested_at'),
-                Forms\Components\Hidden::make('ai_input_tokens'),
-                Forms\Components\Hidden::make('ai_output_tokens'),
-                Forms\Components\Textarea::make('diagnosis')
-                    ->label('Diagnóstico')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000)
-                    ->required(),
-                Forms\Components\Textarea::make('treatment')
-                    ->label('Tratamiento')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000)
-                    ->required(),
-                Forms\Components\Textarea::make('observation')
-                    ->label('Observación')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000),
+                                        Notification::make()
+                                            ->title('Error al generar sugerencia')
+                                            ->body('No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.')
+                                            ->danger()
+                                            ->send();
+                                    }
+                                })
+                                ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
+                        ])->columnSpanFull(),
+                        Forms\Components\Placeholder::make('aiHelp')
+                            ->hiddenLabel()
+                            ->columnSpanFull()
+                            ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                            ->content(new HtmlString(
+                                '<p class="text-sm text-gray-500 dark:text-gray-400">'
+                                .'La IA sugiere un diagnóstico y tratamiento en base a la anamnesis. '
+                                .'Revisá siempre la sugerencia antes de guardar — no reemplaza tu criterio profesional.'
+                                .'</p>'
+                                .'<p wire:loading wire:target="mountFormComponentAction" '
+                                .'class="text-sm font-medium text-primary-600 dark:text-primary-400 mt-1">'
+                                .'Generando sugerencia con IA… esto puede tardar unos segundos.'
+                                .'</p>'
+                            )),
+                        Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
+                        Forms\Components\Hidden::make('ai_treatment_suggestion'),
+                        Forms\Components\Hidden::make('ai_urgency'),
+                        Forms\Components\Hidden::make('ai_suggested_at'),
+                        Forms\Components\Hidden::make('ai_input_tokens'),
+                        Forms\Components\Hidden::make('ai_output_tokens'),
+                        Forms\Components\Textarea::make('diagnosis')
+                            ->label('Diagnóstico')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.')
+                            ->required(),
+                        Forms\Components\Textarea::make('treatment')
+                            ->label('Tratamiento')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.')
+                            ->required(),
+                        Forms\Components\Textarea::make('observation')
+                            ->label('Observación')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.'),
+                    ]),
             ]);
     }
 
@@ -203,7 +215,12 @@ class ConsultationResource extends Resource
                     ->label('IA')
                     ->boolean()
                     ->getStateUsing(fn (Consultation $record) => filled($record->ai_suggested_at)),
+                Tables\Columns\TextColumn::make('ai_urgency')
+                    ->label('Urgencia IA')
+                    ->badge()
+                    ->placeholder('—'),
                 Tables\Columns\TextColumn::make('user.name')
+                    ->label('Veterinario')
                     ->searchable()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -216,6 +233,7 @@ class ConsultationResource extends Resource
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
+            ->defaultSort('consultation_date', 'desc')
             ->filters([
                 Tables\Filters\Filter::make('consultation_date')
                     ->label('Fecha de consulta')

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -18,6 +18,7 @@ use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\HtmlString;
 
 /**
  * Gestión de consultas veterinarias, con diagnóstico asistido por IA.
@@ -97,6 +98,16 @@ class ConsultationResource extends Resource
                                     return;
                                 }
 
+                                if (blank($get('anamnesis'))) {
+                                    Notification::make()
+                                        ->title('Completá la anamnesis primero')
+                                        ->body('La IA necesita la anamnesis para poder sugerir un diagnóstico.')
+                                        ->warning()
+                                        ->send();
+
+                                    return;
+                                }
+
                                 $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
                                 $set('diagnosis', $result['diagnosis']);
                                 $set('treatment', $result['treatment']);
@@ -126,6 +137,20 @@ class ConsultationResource extends Resource
                         })
                         ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
                 ])->columnSpanFull(),
+                Forms\Components\Placeholder::make('aiHelp')
+                    ->hiddenLabel()
+                    ->columnSpanFull()
+                    ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                    ->content(new HtmlString(
+                        '<p class="text-sm text-gray-500 dark:text-gray-400">'
+                        .'La IA sugiere un diagnóstico y tratamiento en base a la anamnesis. '
+                        .'Revisá siempre la sugerencia antes de guardar — no reemplaza tu criterio profesional.'
+                        .'</p>'
+                        .'<p wire:loading wire:target="mountFormComponentAction" '
+                        .'class="text-sm font-medium text-primary-600 dark:text-primary-400 mt-1">'
+                        .'Generando sugerencia con IA… esto puede tardar unos segundos.'
+                        .'</p>'
+                    )),
                 Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
                 Forms\Components\Hidden::make('ai_treatment_suggestion'),
                 Forms\Components\Hidden::make('ai_urgency'),

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -6,6 +6,7 @@ use App\Filament\Concerns\ClinicRoles;
 use App\Filament\Concerns\HasClinicResourceAuthorization;
 use App\Filament\Resources\ConsultationResource\Pages;
 use App\Models\Consultation;
+use App\Models\Pet;
 use App\Services\AIDiagnosticService;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -43,17 +44,28 @@ class ConsultationResource extends Resource
         return [ClinicRoles::ADMIN, ClinicRoles::VETERINARIAN];
     }
 
+    protected static function aiSuggestOverwritesExisting(Get $get): bool
+    {
+        return filled($get('diagnosis')) || filled($get('treatment'));
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
                 Forms\Components\Select::make('pet_id')
-                    ->label('Pet id')
+                    ->label('Mascota')
                     ->relationship('pet', 'name')
                     ->searchable(['name', 'id'])
                     ->preload()
                     ->live()
                     ->required(),
+                Forms\Components\DatePicker::make('consultation_date')
+                    ->label('Fecha de consulta')
+                    ->required()
+                    ->native(false)
+                    ->maxDate(now())
+                    ->default(now()),
                 Forms\Components\Textarea::make('anamnesis')
                     ->label('Anamnesis')
                     ->columnSpanFull()
@@ -62,11 +74,25 @@ class ConsultationResource extends Resource
                 Forms\Components\Actions::make([
                     Forms\Components\Actions\Action::make('aiSuggest')
                         ->label('Asistir con IA')
+                        ->modalHeading(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Sobrescribir sugerencia existente' : null)
+                        ->modalDescription(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Ya hay contenido en Diagnóstico o Tratamiento. ¿Querés reemplazarlo con la sugerencia de la IA?' : null)
+                        ->modalSubmitActionLabel(fn (Get $get) => static::aiSuggestOverwritesExisting($get) ? 'Sí, sobrescribir' : null)
+                        ->requiresConfirmation(fn (Get $get) => static::aiSuggestOverwritesExisting($get))
                         ->icon('heroicon-o-sparkles')
                         ->color('info')
-                        ->action(function (Get $get, Set $set, $record) {
+                        ->action(function (Get $get, Set $set) {
                             try {
-                                $pet = $record?->pet;
+                                $pet = Pet::find($get('pet_id'));
+
+                                if (! $pet) {
+                                    Notification::make()
+                                        ->title('Seleccioná una mascota primero')
+                                        ->warning()
+                                        ->send();
+
+                                    return;
+                                }
+
                                 $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
                                 $set('diagnosis', $result['diagnosis']);
                                 $set('treatment', $result['treatment']);
@@ -80,7 +106,7 @@ class ConsultationResource extends Resource
                                     ->send();
                             }
                         })
-                        ->hidden(fn ($record) => $record === null || ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
+                        ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
                 ])->columnSpanFull(),
                 Forms\Components\Textarea::make('diagnosis')
                     ->label('Diagnóstico')
@@ -111,6 +137,10 @@ class ConsultationResource extends Resource
                 Tables\Columns\TextColumn::make('pet.name')
                     ->label('Mascota')
                     ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('consultation_date')
+                    ->label('Fecha de consulta')
+                    ->date()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('diagnosis')
                     ->label('Diagnóstico')

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -55,7 +55,10 @@ class ConsultationResource extends Resource
             ->schema([
                 Forms\Components\Select::make('pet_id')
                     ->label('Mascota')
-                    ->relationship('pet', 'name')
+                    ->relationship('pet', 'name', modifyQueryUsing: fn (Builder $query, ?Consultation $record) => $query->where(
+                        fn (Builder $q) => $q->where('active', true)
+                            ->when($record?->pet_id, fn (Builder $q, $petId) => $q->orWhere('id', $petId))
+                    ))
                     ->searchable(['name', 'id'])
                     ->preload()
                     ->live()
@@ -70,6 +73,7 @@ class ConsultationResource extends Resource
                     ->label('Anamnesis')
                     ->columnSpanFull()
                     ->autosize()
+                    ->maxLength(5000)
                     ->required(),
                 Forms\Components\Actions::make([
                     Forms\Components\Actions\Action::make('aiSuggest')
@@ -112,16 +116,19 @@ class ConsultationResource extends Resource
                     ->label('Diagnóstico')
                     ->columnSpanFull()
                     ->autosize()
+                    ->maxLength(5000)
                     ->required(),
                 Forms\Components\Textarea::make('treatment')
                     ->label('Tratamiento')
                     ->columnSpanFull()
                     ->autosize()
+                    ->maxLength(5000)
                     ->required(),
                 Forms\Components\Textarea::make('observation')
                     ->label('Observación')
                     ->columnSpanFull()
-                    ->autosize(),
+                    ->autosize()
+                    ->maxLength(5000),
             ]);
     }
 
@@ -145,7 +152,8 @@ class ConsultationResource extends Resource
                 Tables\Columns\TextColumn::make('diagnosis')
                     ->label('Diagnóstico')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->limit(60),
                 Tables\Columns\TextColumn::make('user.name')
                     ->searchable()
                     ->sortable()
@@ -160,16 +168,16 @@ class ConsultationResource extends Resource
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                Tables\Filters\Filter::make('created_at')
-                    ->label('Creado a las')
+                Tables\Filters\Filter::make('consultation_date')
+                    ->label('Fecha de consulta')
                     ->form([
                         Forms\Components\DatePicker::make('from')->label('Desde')->native(false),
                         Forms\Components\DatePicker::make('until')->label('Hasta')->native(false),
                     ])
                     ->query(function (Builder $query, array $data): Builder {
                         return $query
-                            ->when($data['from'], fn (Builder $query, $date) => $query->whereDate('created_at', '>=', $date))
-                            ->when($data['until'], fn (Builder $query, $date) => $query->whereDate('created_at', '<=', $date));
+                            ->when($data['from'], fn (Builder $query, $date) => $query->whereDate('consultation_date', '>=', $date))
+                            ->when($data['until'], fn (Builder $query, $date) => $query->whereDate('consultation_date', '<=', $date));
                     }),
             ])
             ->actions([

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -100,6 +100,20 @@ class ConsultationResource extends Resource
                                 $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
                                 $set('diagnosis', $result['diagnosis']);
                                 $set('treatment', $result['treatment']);
+                                $set('ai_diagnosis_suggestion', $result['diagnosis']);
+                                $set('ai_treatment_suggestion', $result['treatment']);
+                                $set('ai_urgency', $result['urgency']);
+                                $set('ai_suggested_at', now());
+                                $set('ai_input_tokens', $result['input_tokens']);
+                                $set('ai_output_tokens', $result['output_tokens']);
+
+                                if (in_array($result['urgency'], ['alta', 'emergencia'], true)) {
+                                    Notification::make()
+                                        ->title('Posible urgencia detectada')
+                                        ->body('La IA marcó esta consulta con urgencia "'.$result['urgency'].'". Priorizá la revisión del paciente.')
+                                        ->danger()
+                                        ->send();
+                                }
                             } catch (\Throwable $e) {
                                 Log::error('Error en sugerencia de IA: '.$e->getMessage());
 
@@ -112,6 +126,12 @@ class ConsultationResource extends Resource
                         })
                         ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian'])),
                 ])->columnSpanFull(),
+                Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
+                Forms\Components\Hidden::make('ai_treatment_suggestion'),
+                Forms\Components\Hidden::make('ai_urgency'),
+                Forms\Components\Hidden::make('ai_suggested_at'),
+                Forms\Components\Hidden::make('ai_input_tokens'),
+                Forms\Components\Hidden::make('ai_output_tokens'),
                 Forms\Components\Textarea::make('diagnosis')
                     ->label('Diagnóstico')
                     ->columnSpanFull()
@@ -154,6 +174,10 @@ class ConsultationResource extends Resource
                     ->searchable()
                     ->sortable()
                     ->limit(60),
+                Tables\Columns\IconColumn::make('ai_suggested_at')
+                    ->label('IA')
+                    ->boolean()
+                    ->getStateUsing(fn (Consultation $record) => filled($record->ai_suggested_at)),
                 Tables\Columns\TextColumn::make('user.name')
                     ->searchable()
                     ->sortable()

--- a/app/Filament/Resources/ConsultationResource/Pages/ViewConsultation.php
+++ b/app/Filament/Resources/ConsultationResource/Pages/ViewConsultation.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ConsultationResource\Pages;
 
 use App\Filament\Resources\ConsultationResource;
+use App\Models\Consultation;
 use Filament\Actions;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
@@ -38,6 +39,29 @@ class ViewConsultation extends ViewRecord
                         TextEntry::make('diagnosis')->label('Diagnóstico')->columnSpanFull(),
                         TextEntry::make('treatment')->label('Tratamiento')->columnSpanFull(),
                         TextEntry::make('observation')->label('Observación')->columnSpanFull()
+                            ->placeholder('—'),
+                    ]),
+
+                Section::make('Diagnóstico asistido por IA')
+                    ->columns(2)
+                    ->visible(fn (Consultation $record) => filled($record->ai_suggested_at))
+                    ->schema([
+                        TextEntry::make('ai_usage_status')
+                            ->label('Estado')
+                            ->state(fn (Consultation $record) => $record->aiUsageStatus())
+                            ->badge(),
+                        TextEntry::make('ai_urgency')
+                            ->label('Urgencia detectada')
+                            ->badge()
+                            ->placeholder('—'),
+                        TextEntry::make('ai_suggested_at')
+                            ->label('Sugerido el')
+                            ->dateTime(),
+                        TextEntry::make('ai_input_tokens')
+                            ->label('Tokens (entrada)')
+                            ->placeholder('—'),
+                        TextEntry::make('ai_output_tokens')
+                            ->label('Tokens (salida)')
                             ->placeholder('—'),
                     ]),
             ]);

--- a/app/Filament/Resources/ConsultationResource/Pages/ViewConsultation.php
+++ b/app/Filament/Resources/ConsultationResource/Pages/ViewConsultation.php
@@ -3,12 +3,15 @@
 namespace App\Filament\Resources\ConsultationResource\Pages;
 
 use App\Filament\Resources\ConsultationResource;
+use App\Filament\Resources\PetResource;
+use App\Filament\Resources\UserResource;
 use App\Models\Consultation;
 use Filament\Actions;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\HtmlString;
 
 class ViewConsultation extends ViewRecord
 {
@@ -28,18 +31,38 @@ class ViewConsultation extends ViewRecord
                 Section::make('Información general')
                     ->columns(2)
                     ->schema([
-                        TextEntry::make('pet.name')->label('Mascota'),
-                        TextEntry::make('user.name')->label('Veterinario'),
+                        TextEntry::make('pet.name')
+                            ->label('Mascota')
+                            ->url(fn (Consultation $record) => PetResource::getUrl('view', ['record' => $record->pet_id])),
+                        TextEntry::make('user.name')
+                            ->label('Veterinario')
+                            ->url(fn (Consultation $record) => auth()->user()?->hasRole('admin')
+                                ? UserResource::getUrl('view', ['record' => $record->user_id])
+                                : null),
                         TextEntry::make('consultation_date')->label('Fecha de consulta')->date(),
+                        TextEntry::make('created_at')->label('Registrado el')->dateTime(),
+                        TextEntry::make('updated_at')->label('Última edición')->dateTime(),
                     ]),
 
                 Section::make('Consulta')
                     ->schema([
-                        TextEntry::make('anamnesis')->label('Anamnesis')->columnSpanFull(),
-                        TextEntry::make('diagnosis')->label('Diagnóstico')->columnSpanFull(),
-                        TextEntry::make('treatment')->label('Tratamiento')->columnSpanFull(),
-                        TextEntry::make('observation')->label('Observación')->columnSpanFull()
-                            ->placeholder('—'),
+                        TextEntry::make('anamnesis')
+                            ->label('Anamnesis')
+                            ->columnSpanFull()
+                            ->formatStateUsing(fn (?string $state) => filled($state) ? new HtmlString(nl2br(e($state))) : null),
+                        TextEntry::make('diagnosis')
+                            ->label('Diagnóstico')
+                            ->columnSpanFull()
+                            ->formatStateUsing(fn (?string $state) => filled($state) ? new HtmlString(nl2br(e($state))) : null),
+                        TextEntry::make('treatment')
+                            ->label('Tratamiento')
+                            ->columnSpanFull()
+                            ->formatStateUsing(fn (?string $state) => filled($state) ? new HtmlString(nl2br(e($state))) : null),
+                        TextEntry::make('observation')
+                            ->label('Observación')
+                            ->columnSpanFull()
+                            ->placeholder('—')
+                            ->formatStateUsing(fn (?string $state) => filled($state) ? new HtmlString(nl2br(e($state))) : null),
                     ]),
 
                 Section::make('Diagnóstico asistido por IA')

--- a/app/Filament/Resources/ConsultationResource/Pages/ViewConsultation.php
+++ b/app/Filament/Resources/ConsultationResource/Pages/ViewConsultation.php
@@ -29,6 +29,7 @@ class ViewConsultation extends ViewRecord
                     ->schema([
                         TextEntry::make('pet.name')->label('Mascota'),
                         TextEntry::make('user.name')->label('Veterinario'),
+                        TextEntry::make('consultation_date')->label('Fecha de consulta')->date(),
                     ]),
 
                 Section::make('Consulta')

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -7,6 +7,7 @@ use App\Filament\Concerns\HasClinicRelationManagerAuthorization;
 use App\Models\Consultation;
 use App\Services\AIDiagnosticService;
 use Filament\Forms;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
@@ -48,106 +49,113 @@ class ConsultationsRelationManager extends RelationManager
     {
         return $form
             ->schema([
-                Forms\Components\DatePicker::make('consultation_date')
-                    ->label('Fecha de consulta')
-                    ->required()
-                    ->native(false)
-                    ->maxDate(now())
-                    ->default(now()),
-                Forms\Components\Textarea::make('anamnesis')
-                    ->label('Anamnesis')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000)
-                    ->required(),
-                Forms\Components\Actions::make([
-                    Forms\Components\Actions\Action::make('aiSuggest')
-                        ->label('Asistir con IA')
-                        ->icon('heroicon-o-sparkles')
-                        ->color('info')
-                        ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
-                        ->modalHeading(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Sobrescribir sugerencia existente' : null)
-                        ->modalDescription(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Ya hay contenido en Diagnóstico o Tratamiento. ¿Querés reemplazarlo con la sugerencia de la IA?' : null)
-                        ->modalSubmitActionLabel(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Sí, sobrescribir' : null)
-                        ->requiresConfirmation(fn (Get $get) => $this->aiSuggestOverwritesExisting($get))
-                        ->action(function (Get $get, Set $set, $livewire) {
-                            try {
-                                if (blank($get('anamnesis'))) {
-                                    Notification::make()
-                                        ->title('Completá la anamnesis primero')
-                                        ->body('La IA necesita la anamnesis para poder sugerir un diagnóstico.')
-                                        ->warning()
-                                        ->send();
+                Section::make('Consulta')
+                    ->schema([
+                        Forms\Components\DatePicker::make('consultation_date')
+                            ->label('Fecha de consulta')
+                            ->required()
+                            ->native(false)
+                            ->maxDate(now())
+                            ->default(now()),
+                        Forms\Components\Textarea::make('anamnesis')
+                            ->label('Anamnesis')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.')
+                            ->required(),
+                        Forms\Components\Actions::make([
+                            Forms\Components\Actions\Action::make('aiSuggest')
+                                ->label('Asistir con IA')
+                                ->icon('heroicon-o-sparkles')
+                                ->color('info')
+                                ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                                ->modalHeading(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Sobrescribir sugerencia existente' : null)
+                                ->modalDescription(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Ya hay contenido en Diagnóstico o Tratamiento. ¿Querés reemplazarlo con la sugerencia de la IA?' : null)
+                                ->modalSubmitActionLabel(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Sí, sobrescribir' : null)
+                                ->requiresConfirmation(fn (Get $get) => $this->aiSuggestOverwritesExisting($get))
+                                ->action(function (Get $get, Set $set, $livewire) {
+                                    try {
+                                        if (blank($get('anamnesis'))) {
+                                            Notification::make()
+                                                ->title('Completá la anamnesis primero')
+                                                ->body('La IA necesita la anamnesis para poder sugerir un diagnóstico.')
+                                                ->warning()
+                                                ->send();
 
-                                    return;
-                                }
+                                            return;
+                                        }
 
-                                $pet = $livewire->getOwnerRecord();
-                                $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
-                                $set('diagnosis', $result['diagnosis']);
-                                $set('treatment', $result['treatment']);
-                                $set('ai_diagnosis_suggestion', $result['diagnosis']);
-                                $set('ai_treatment_suggestion', $result['treatment']);
-                                $set('ai_urgency', $result['urgency']);
-                                $set('ai_suggested_at', now());
-                                $set('ai_input_tokens', $result['input_tokens']);
-                                $set('ai_output_tokens', $result['output_tokens']);
+                                        $pet = $livewire->getOwnerRecord();
+                                        $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
+                                        $set('diagnosis', $result['diagnosis']);
+                                        $set('treatment', $result['treatment']);
+                                        $set('ai_diagnosis_suggestion', $result['diagnosis']);
+                                        $set('ai_treatment_suggestion', $result['treatment']);
+                                        $set('ai_urgency', $result['urgency']);
+                                        $set('ai_suggested_at', now());
+                                        $set('ai_input_tokens', $result['input_tokens']);
+                                        $set('ai_output_tokens', $result['output_tokens']);
 
-                                if (in_array($result['urgency'], ['alta', 'emergencia'], true)) {
-                                    Notification::make()
-                                        ->title('Posible urgencia detectada')
-                                        ->body('La IA marcó esta consulta con urgencia "'.$result['urgency'].'". Priorizá la revisión del paciente.')
-                                        ->danger()
-                                        ->send();
-                                }
-                            } catch (\Throwable $e) {
-                                Log::error('Error en sugerencia de IA: '.$e->getMessage());
+                                        if (in_array($result['urgency'], ['alta', 'emergencia'], true)) {
+                                            Notification::make()
+                                                ->title('Posible urgencia detectada')
+                                                ->body('La IA marcó esta consulta con urgencia "'.$result['urgency'].'". Priorizá la revisión del paciente.')
+                                                ->danger()
+                                                ->send();
+                                        }
+                                    } catch (\Throwable $e) {
+                                        Log::error('Error en sugerencia de IA: '.$e->getMessage());
 
-                                Notification::make()
-                                    ->title('Error al generar sugerencia')
-                                    ->body('No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.')
-                                    ->danger()
-                                    ->send();
-                            }
-                        }),
-                ])->columnSpanFull(),
-                Forms\Components\Placeholder::make('aiHelp')
-                    ->hiddenLabel()
-                    ->columnSpanFull()
-                    ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
-                    ->content(new HtmlString(
-                        '<p class="text-sm text-gray-500 dark:text-gray-400">'
-                        .'La IA sugiere un diagnóstico y tratamiento en base a la anamnesis. '
-                        .'Revisá siempre la sugerencia antes de guardar — no reemplaza tu criterio profesional.'
-                        .'</p>'
-                        .'<p wire:loading wire:target="mountFormComponentAction" '
-                        .'class="text-sm font-medium text-primary-600 dark:text-primary-400 mt-1">'
-                        .'Generando sugerencia con IA… esto puede tardar unos segundos.'
-                        .'</p>'
-                    )),
-                Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
-                Forms\Components\Hidden::make('ai_treatment_suggestion'),
-                Forms\Components\Hidden::make('ai_urgency'),
-                Forms\Components\Hidden::make('ai_suggested_at'),
-                Forms\Components\Hidden::make('ai_input_tokens'),
-                Forms\Components\Hidden::make('ai_output_tokens'),
-                Forms\Components\Textarea::make('diagnosis')
-                    ->label('Diagnóstico')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000)
-                    ->required(),
-                Forms\Components\Textarea::make('treatment')
-                    ->label('Tratamiento')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000)
-                    ->required(),
-                Forms\Components\Textarea::make('observation')
-                    ->label('Observación')
-                    ->columnSpanFull()
-                    ->autosize()
-                    ->maxLength(5000),
+                                        Notification::make()
+                                            ->title('Error al generar sugerencia')
+                                            ->body('No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.')
+                                            ->danger()
+                                            ->send();
+                                    }
+                                }),
+                        ])->columnSpanFull(),
+                        Forms\Components\Placeholder::make('aiHelp')
+                            ->hiddenLabel()
+                            ->columnSpanFull()
+                            ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                            ->content(new HtmlString(
+                                '<p class="text-sm text-gray-500 dark:text-gray-400">'
+                                .'La IA sugiere un diagnóstico y tratamiento en base a la anamnesis. '
+                                .'Revisá siempre la sugerencia antes de guardar — no reemplaza tu criterio profesional.'
+                                .'</p>'
+                                .'<p wire:loading wire:target="mountFormComponentAction" '
+                                .'class="text-sm font-medium text-primary-600 dark:text-primary-400 mt-1">'
+                                .'Generando sugerencia con IA… esto puede tardar unos segundos.'
+                                .'</p>'
+                            )),
+                        Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
+                        Forms\Components\Hidden::make('ai_treatment_suggestion'),
+                        Forms\Components\Hidden::make('ai_urgency'),
+                        Forms\Components\Hidden::make('ai_suggested_at'),
+                        Forms\Components\Hidden::make('ai_input_tokens'),
+                        Forms\Components\Hidden::make('ai_output_tokens'),
+                        Forms\Components\Textarea::make('diagnosis')
+                            ->label('Diagnóstico')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.')
+                            ->required(),
+                        Forms\Components\Textarea::make('treatment')
+                            ->label('Tratamiento')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.')
+                            ->required(),
+                        Forms\Components\Textarea::make('observation')
+                            ->label('Observación')
+                            ->columnSpanFull()
+                            ->autosize()
+                            ->maxLength(5000)
+                            ->helperText('Máximo 5000 caracteres.'),
+                    ]),
             ]);
     }
 
@@ -173,6 +181,10 @@ class ConsultationsRelationManager extends RelationManager
                     ->label('IA')
                     ->boolean()
                     ->getStateUsing(fn (Consultation $record) => filled($record->ai_suggested_at)),
+                Tables\Columns\TextColumn::make('ai_urgency')
+                    ->label('Urgencia IA')
+                    ->badge()
+                    ->placeholder('—'),
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Usuario')
                     ->searchable()
@@ -189,6 +201,7 @@ class ConsultationsRelationManager extends RelationManager
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
+            ->defaultSort('consultation_date', 'desc')
             ->filters([
                 Tables\Filters\Filter::make('created_at')
                     ->label('Creado a las')

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -17,6 +17,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\HtmlString;
 
 class ConsultationsRelationManager extends RelationManager
 {
@@ -71,6 +72,16 @@ class ConsultationsRelationManager extends RelationManager
                         ->requiresConfirmation(fn (Get $get) => $this->aiSuggestOverwritesExisting($get))
                         ->action(function (Get $get, Set $set, $livewire) {
                             try {
+                                if (blank($get('anamnesis'))) {
+                                    Notification::make()
+                                        ->title('Completá la anamnesis primero')
+                                        ->body('La IA necesita la anamnesis para poder sugerir un diagnóstico.')
+                                        ->warning()
+                                        ->send();
+
+                                    return;
+                                }
+
                                 $pet = $livewire->getOwnerRecord();
                                 $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
                                 $set('diagnosis', $result['diagnosis']);
@@ -100,6 +111,20 @@ class ConsultationsRelationManager extends RelationManager
                             }
                         }),
                 ])->columnSpanFull(),
+                Forms\Components\Placeholder::make('aiHelp')
+                    ->hiddenLabel()
+                    ->columnSpanFull()
+                    ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                    ->content(new HtmlString(
+                        '<p class="text-sm text-gray-500 dark:text-gray-400">'
+                        .'La IA sugiere un diagnóstico y tratamiento en base a la anamnesis. '
+                        .'Revisá siempre la sugerencia antes de guardar — no reemplaza tu criterio profesional.'
+                        .'</p>'
+                        .'<p wire:loading wire:target="mountFormComponentAction" '
+                        .'class="text-sm font-medium text-primary-600 dark:text-primary-400 mt-1">'
+                        .'Generando sugerencia con IA… esto puede tardar unos segundos.'
+                        .'</p>'
+                    )),
                 Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
                 Forms\Components\Hidden::make('ai_treatment_suggestion'),
                 Forms\Components\Hidden::make('ai_urgency'),

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -37,10 +37,21 @@ class ConsultationsRelationManager extends RelationManager
         return [ClinicRoles::ADMIN, ClinicRoles::VETERINARIAN];
     }
 
+    protected function aiSuggestOverwritesExisting(Get $get): bool
+    {
+        return filled($get('diagnosis')) || filled($get('treatment'));
+    }
+
     public function form(Form $form): Form
     {
         return $form
             ->schema([
+                Forms\Components\DatePicker::make('consultation_date')
+                    ->label('Fecha de consulta')
+                    ->required()
+                    ->native(false)
+                    ->maxDate(now())
+                    ->default(now()),
                 Forms\Components\Textarea::make('anamnesis')
                     ->label('Anamnesis')
                     ->columnSpanFull()
@@ -52,6 +63,10 @@ class ConsultationsRelationManager extends RelationManager
                         ->icon('heroicon-o-sparkles')
                         ->color('info')
                         ->hidden(fn () => ! auth()->user()?->hasAnyRole(['admin', 'veterinarian']))
+                        ->modalHeading(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Sobrescribir sugerencia existente' : null)
+                        ->modalDescription(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Ya hay contenido en Diagnóstico o Tratamiento. ¿Querés reemplazarlo con la sugerencia de la IA?' : null)
+                        ->modalSubmitActionLabel(fn (Get $get) => $this->aiSuggestOverwritesExisting($get) ? 'Sí, sobrescribir' : null)
+                        ->requiresConfirmation(fn (Get $get) => $this->aiSuggestOverwritesExisting($get))
                         ->action(function (Get $get, Set $set, $livewire) {
                             try {
                                 $pet = $livewire->getOwnerRecord();
@@ -95,6 +110,10 @@ class ConsultationsRelationManager extends RelationManager
                     ->searchable()
                     ->sortable()
                     ->numeric(),
+                Tables\Columns\TextColumn::make('consultation_date')
+                    ->label('Fecha de consulta')
+                    ->date()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('diagnosis')
                     ->label('Diagnóstico')
                     ->searchable()

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -56,6 +56,7 @@ class ConsultationsRelationManager extends RelationManager
                     ->label('Anamnesis')
                     ->columnSpanFull()
                     ->autosize()
+                    ->maxLength(5000)
                     ->required(),
                 Forms\Components\Actions::make([
                     Forms\Components\Actions\Action::make('aiSuggest')
@@ -88,16 +89,19 @@ class ConsultationsRelationManager extends RelationManager
                     ->label('Diagnóstico')
                     ->columnSpanFull()
                     ->autosize()
+                    ->maxLength(5000)
                     ->required(),
                 Forms\Components\Textarea::make('treatment')
                     ->label('Tratamiento')
                     ->columnSpanFull()
                     ->autosize()
+                    ->maxLength(5000)
                     ->required(),
                 Forms\Components\Textarea::make('observation')
                     ->label('Observación')
                     ->columnSpanFull()
-                    ->autosize(),
+                    ->autosize()
+                    ->maxLength(5000),
             ]);
     }
 

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\PetResource\RelationManagers;
 
 use App\Filament\Concerns\ClinicRoles;
 use App\Filament\Concerns\HasClinicRelationManagerAuthorization;
+use App\Models\Consultation;
 use App\Services\AIDiagnosticService;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -74,6 +75,20 @@ class ConsultationsRelationManager extends RelationManager
                                 $result = app(AIDiagnosticService::class)->suggest($pet, $get('anamnesis'));
                                 $set('diagnosis', $result['diagnosis']);
                                 $set('treatment', $result['treatment']);
+                                $set('ai_diagnosis_suggestion', $result['diagnosis']);
+                                $set('ai_treatment_suggestion', $result['treatment']);
+                                $set('ai_urgency', $result['urgency']);
+                                $set('ai_suggested_at', now());
+                                $set('ai_input_tokens', $result['input_tokens']);
+                                $set('ai_output_tokens', $result['output_tokens']);
+
+                                if (in_array($result['urgency'], ['alta', 'emergencia'], true)) {
+                                    Notification::make()
+                                        ->title('Posible urgencia detectada')
+                                        ->body('La IA marcó esta consulta con urgencia "'.$result['urgency'].'". Priorizá la revisión del paciente.')
+                                        ->danger()
+                                        ->send();
+                                }
                             } catch (\Throwable $e) {
                                 Log::error('Error en sugerencia de IA: '.$e->getMessage());
 
@@ -85,6 +100,12 @@ class ConsultationsRelationManager extends RelationManager
                             }
                         }),
                 ])->columnSpanFull(),
+                Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
+                Forms\Components\Hidden::make('ai_treatment_suggestion'),
+                Forms\Components\Hidden::make('ai_urgency'),
+                Forms\Components\Hidden::make('ai_suggested_at'),
+                Forms\Components\Hidden::make('ai_input_tokens'),
+                Forms\Components\Hidden::make('ai_output_tokens'),
                 Forms\Components\Textarea::make('diagnosis')
                     ->label('Diagnóstico')
                     ->columnSpanFull()
@@ -121,7 +142,12 @@ class ConsultationsRelationManager extends RelationManager
                 Tables\Columns\TextColumn::make('diagnosis')
                     ->label('Diagnóstico')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->limit(60),
+                Tables\Columns\IconColumn::make('ai_suggested_at')
+                    ->label('IA')
+                    ->boolean()
+                    ->getStateUsing(fn (Consultation $record) => filled($record->ai_suggested_at)),
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Usuario')
                     ->searchable()

--- a/app/Filament/Resources/SurgeryResource.php
+++ b/app/Filament/Resources/SurgeryResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Gestión de cirugías realizadas a las mascotas.
@@ -80,7 +81,10 @@ class SurgeryResource extends Resource
                     ->schema([
                         Forms\Components\Select::make('pet_id')
                             ->label('Pet id')
-                            ->relationship('pet', 'name')
+                            ->relationship('pet', 'name', modifyQueryUsing: fn (Builder $query, ?Surgery $record) => $query->where(
+                                fn (Builder $q) => $q->where('active', true)
+                                    ->when($record?->pet_id, fn (Builder $q, $petId) => $q->orWhere('id', $petId))
+                            ))
                             ->searchable(['name', 'id'])
                             ->preload()
                             ->live()

--- a/app/Filament/Resources/TestResource.php
+++ b/app/Filament/Resources/TestResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Gestión de pruebas laboratoriales realizadas a las mascotas.
@@ -67,7 +68,10 @@ class TestResource extends Resource
                     ->schema([
                         Forms\Components\Select::make('pet_id')
                             ->label('Pet id')
-                            ->relationship('pet', 'name')
+                            ->relationship('pet', 'name', modifyQueryUsing: fn (Builder $query, ?Test $record) => $query->where(
+                                fn (Builder $q) => $q->where('active', true)
+                                    ->when($record?->pet_id, fn (Builder $q, $petId) => $q->orWhere('id', $petId))
+                            ))
                             ->searchable(['name', 'id'])
                             ->preload()
                             ->live()

--- a/app/Filament/Resources/VaccinationResource.php
+++ b/app/Filament/Resources/VaccinationResource.php
@@ -134,7 +134,10 @@ class VaccinationResource extends Resource
                     ->required(),
                 Forms\Components\Select::make('pet_id')
                     ->label('Pet id')
-                    ->relationship('pet', 'name')
+                    ->relationship('pet', 'name', modifyQueryUsing: fn (Builder $query, ?Vaccination $record) => $query->where(
+                        fn (Builder $q) => $q->where('active', true)
+                            ->when($record?->pet_id, fn (Builder $q, $petId) => $q->orWhere('id', $petId))
+                    ))
                     ->searchable(['name', 'id'])
                     ->preload()
                     ->live()

--- a/app/Filament/Widgets/RecentConsultationsWidget.php
+++ b/app/Filament/Widgets/RecentConsultationsWidget.php
@@ -26,7 +26,7 @@ class RecentConsultationsWidget extends BaseWidget
             ->query(
                 Consultation::query()
                     ->with(['pet', 'user'])
-                    ->latest()
+                    ->latest('consultation_date')
                     ->limit(5)
             )
             ->columns([
@@ -37,9 +37,9 @@ class RecentConsultationsWidget extends BaseWidget
                     ->limit(60),
                 Tables\Columns\TextColumn::make('user.name')
                     ->label('Veterinario'),
-                Tables\Columns\TextColumn::make('created_at')
+                Tables\Columns\TextColumn::make('consultation_date')
                     ->label('Fecha')
-                    ->dateTime('d/m/Y H:i')
+                    ->date('d/m/Y')
                     ->sortable(),
             ])
             ->recordUrl(fn (Consultation $record) => ConsultationResource::getUrl('view', ['record' => $record]))

--- a/app/Models/Consultation.php
+++ b/app/Models/Consultation.php
@@ -26,6 +26,13 @@ class Consultation extends Model
         'user_id', // ID del usuario (veterinario) que creó la consulta
     ];
 
+    protected function casts(): array
+    {
+        return [
+            'consultation_date' => 'date',
+        ];
+    }
+
     /**
      * Una consulta pertenece a una mascota.
      * Esta relación define que cada consulta está asociada con una mascota específica.

--- a/app/Models/Consultation.php
+++ b/app/Models/Consultation.php
@@ -21,6 +21,7 @@ class Consultation extends Model
         'diagnosis', // Diagnóstico del paciente
         'treatment', // Tratamiento prescrito
         'observation', // Observaciones adicionales
+        'consultation_date', // Fecha en la que ocurrió la consulta
         'pet_id', // ID de la mascota asociada a la consulta
         'user_id', // ID del usuario (veterinario) que creó la consulta
     ];
@@ -28,8 +29,6 @@ class Consultation extends Model
     /**
      * Una consulta pertenece a una mascota.
      * Esta relación define que cada consulta está asociada con una mascota específica.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function pet(): BelongsTo
     {
@@ -39,8 +38,6 @@ class Consultation extends Model
     /**
      * Una consulta pertenece a un usuario (veterinario).
      * Esta relación define que cada consulta está asociada con un veterinario específico.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user(): BelongsTo
     {

--- a/app/Models/Consultation.php
+++ b/app/Models/Consultation.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\AiUrgencyLevel;
+use App\Enums\AiUsageStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,13 +26,38 @@ class Consultation extends Model
         'consultation_date', // Fecha en la que ocurrió la consulta
         'pet_id', // ID de la mascota asociada a la consulta
         'user_id', // ID del usuario (veterinario) que creó la consulta
+        'ai_diagnosis_suggestion', // Diagnóstico crudo sugerido por la IA (para auditoría)
+        'ai_treatment_suggestion', // Tratamiento crudo sugerido por la IA (para auditoría)
+        'ai_urgency', // Nivel de urgencia detectado por la IA
+        'ai_suggested_at', // Cuándo se generó la sugerencia de IA
+        'ai_input_tokens', // Tokens de entrada consumidos por la sugerencia
+        'ai_output_tokens', // Tokens de salida consumidos por la sugerencia
     ];
 
     protected function casts(): array
     {
         return [
             'consultation_date' => 'date',
+            'ai_urgency' => AiUrgencyLevel::class,
+            'ai_suggested_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Indica si el diagnóstico/tratamiento final es manual, una sugerencia de IA usada
+     * tal cual, o una sugerencia de IA que el veterinario editó antes de guardar.
+     */
+    public function aiUsageStatus(): AiUsageStatus
+    {
+        if (is_null($this->ai_suggested_at)) {
+            return AiUsageStatus::Manual;
+        }
+
+        if ($this->diagnosis === $this->ai_diagnosis_suggestion && $this->treatment === $this->ai_treatment_suggestion) {
+            return AiUsageStatus::UsedAsIs;
+        }
+
+        return AiUsageStatus::Edited;
     }
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -57,6 +57,7 @@ class AdminPanelProvider extends PanelProvider
             ->spa()
             ->profile(isSimple: false)
             ->sidebarCollapsibleOnDesktop()
+            ->readOnlyRelationManagersOnResourceViewPagesByDefault(false)
             ->brandName($brandName)
             ->brandLogo($brandLogo)
             ->favicon($favicon)

--- a/app/Services/AIDiagnosticService.php
+++ b/app/Services/AIDiagnosticService.php
@@ -2,8 +2,10 @@
 
 namespace App\Services;
 
+use App\Enums\AiUrgencyLevel;
 use App\Models\Pet;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
 class AIDiagnosticService
@@ -27,7 +29,7 @@ class AIDiagnosticService
         ])->timeout(30)->retry(2, 500, throw: false)->post('https://api.anthropic.com/v1/messages', [
             'model' => config('services.anthropic.model'),
             'max_tokens' => 4096,
-            'system' => 'Eres un veterinario clínico experto. A partir de los datos del paciente y la anamnesis proporcionada, generá un diagnóstico presuntivo y un plan de tratamiento. Respondé ÚNICAMENTE con JSON válido con las claves "diagnosis" y "treatment", sin bloques de código Markdown ni texto adicional antes o después del JSON.',
+            'system' => 'Eres un veterinario clínico experto asistiendo a otro veterinario, no al dueño de la mascota. A partir de los datos del paciente y la anamnesis proporcionada, generá un diagnóstico presuntivo, un plan de tratamiento, y un nivel de urgencia. El diagnóstico es una sugerencia que el veterinario tratante debe confirmar con su propio criterio clínico antes de aplicarla. Si los síntomas descriptos sugieren una condición que pone en riesgo la vida del paciente o requiere atención inmediata, marcá la urgencia como "alta" o "emergencia" y mencionalo explícitamente en el diagnóstico. Respondé ÚNICAMENTE con JSON válido con las claves "diagnosis", "treatment" y "urgency" (uno de: "baja", "media", "alta", "emergencia"), sin bloques de código Markdown ni texto adicional antes o después del JSON.',
             'messages' => [
                 ['role' => 'user', 'content' => $userPrompt],
             ],
@@ -47,6 +49,18 @@ class AIDiagnosticService
             throw new RuntimeException('La respuesta de la IA no tiene el formato esperado.');
         }
 
-        return $result;
+        $urgency = AiUrgencyLevel::tryFrom($result['urgency'] ?? '');
+
+        if (is_null($urgency)) {
+            Log::warning('La IA no devolvió un nivel de urgencia válido.', ['urgency' => $result['urgency'] ?? null]);
+        }
+
+        return [
+            'diagnosis' => $result['diagnosis'],
+            'treatment' => $result['treatment'],
+            'urgency' => $urgency?->value,
+            'input_tokens' => $response->json('usage.input_tokens'),
+            'output_tokens' => $response->json('usage.output_tokens'),
+        ];
     }
 }

--- a/app/Services/AIDiagnosticService.php
+++ b/app/Services/AIDiagnosticService.php
@@ -10,6 +10,10 @@ class AIDiagnosticService
 {
     public function suggest(Pet $pet, string $anamnesis): array
     {
+        if (blank(config('services.anthropic.key'))) {
+            throw new RuntimeException('ANTHROPIC_API_KEY no configurada.');
+        }
+
         $species = $pet->species->getLabel();
         $gender = $pet->gender->getLabel();
         $reproduction = $pet->reproduction->getLabel();
@@ -20,8 +24,8 @@ class AIDiagnosticService
         $response = Http::withHeaders([
             'x-api-key' => config('services.anthropic.key'),
             'anthropic-version' => '2023-06-01',
-        ])->post('https://api.anthropic.com/v1/messages', [
-            'model' => 'claude-opus-4-8',
+        ])->timeout(30)->retry(2, 500, throw: false)->post('https://api.anthropic.com/v1/messages', [
+            'model' => config('services.anthropic.model'),
             'max_tokens' => 4096,
             'system' => 'Eres un veterinario clínico experto. A partir de los datos del paciente y la anamnesis proporcionada, generá un diagnóstico presuntivo y un plan de tratamiento. Respondé ÚNICAMENTE con JSON válido con las claves "diagnosis" y "treatment", sin bloques de código Markdown ni texto adicional antes o después del JSON.',
             'messages' => [

--- a/config/services.php
+++ b/config/services.php
@@ -37,6 +37,7 @@ return [
 
     'anthropic' => [
         'key' => env('ANTHROPIC_API_KEY'),
+        'model' => env('ANTHROPIC_MODEL', 'claude-opus-4-8'),
     ],
 
 ];

--- a/database/factories/ConsultationFactory.php
+++ b/database/factories/ConsultationFactory.php
@@ -21,6 +21,7 @@ class ConsultationFactory extends Factory
             'diagnosis' => fake()->sentence(8),
             'treatment' => fake()->sentence(10),
             'observation' => fake()->optional()->sentence(),
+            'consultation_date' => fake()->dateTimeBetween('-30 days', 'now'),
             'pet_id' => Pet::factory(),
             'user_id' => User::factory(),
         ];

--- a/database/migrations/2026_08_03_000000_add_consultation_date_to_consultations_table.php
+++ b/database/migrations/2026_08_03_000000_add_consultation_date_to_consultations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('consultations', function (Blueprint $table) {
+            $table->date('consultation_date')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('consultations', function (Blueprint $table) {
+            $table->dropColumn('consultation_date');
+        });
+    }
+};

--- a/database/migrations/2026_08_03_000001_add_ai_tracking_to_consultations_table.php
+++ b/database/migrations/2026_08_03_000001_add_ai_tracking_to_consultations_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('consultations', function (Blueprint $table) {
+            $table->text('ai_diagnosis_suggestion')->nullable();
+            $table->text('ai_treatment_suggestion')->nullable();
+            $table->string('ai_urgency')->nullable();
+            $table->timestamp('ai_suggested_at')->nullable();
+            $table->unsignedInteger('ai_input_tokens')->nullable();
+            $table->unsignedInteger('ai_output_tokens')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('consultations', function (Blueprint $table) {
+            $table->dropColumn([
+                'ai_diagnosis_suggestion',
+                'ai_treatment_suggestion',
+                'ai_urgency',
+                'ai_suggested_at',
+                'ai_input_tokens',
+                'ai_output_tokens',
+            ]);
+        });
+    }
+};

--- a/database/seeders/ConsultationSeeder.php
+++ b/database/seeders/ConsultationSeeder.php
@@ -119,14 +119,15 @@ class ConsultationSeeder extends Seeder
             $vet = $vets->random();
 
             Consultation::create([
-                'anamnesis'   => $anamnesis,
-                'diagnosis'   => $diagnosis,
-                'treatment'   => $treatment,
+                'anamnesis' => $anamnesis,
+                'diagnosis' => $diagnosis,
+                'treatment' => $treatment,
                 'observation' => $observation,
-                'pet_id'      => $pet->id,
-                'user_id'     => $vet->id,
-                'created_at'  => now()->subDays($daysAgo),
-                'updated_at'  => now()->subDays($daysAgo),
+                'consultation_date' => now()->subDays($daysAgo)->toDateString(),
+                'pet_id' => $pet->id,
+                'user_id' => $vet->id,
+                'created_at' => now()->subDays($daysAgo),
+                'updated_at' => now()->subDays($daysAgo),
             ]);
         }
     }

--- a/tests/Feature/Regression/ConsultationAiSuggestTest.php
+++ b/tests/Feature/Regression/ConsultationAiSuggestTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Filament\Resources\ConsultationResource\Pages\CreateConsultation;
+use App\Filament\Resources\PetResource\Pages\EditPet;
+use App\Filament\Resources\PetResource\RelationManagers\ConsultationsRelationManager;
+use App\Models\Pet;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    config(['services.anthropic.key' => 'test-key']);
+});
+
+function fakeAiResponse(string $diagnosis = 'Diagnóstico IA', string $treatment = 'Tratamiento IA'): void
+{
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'content' => [
+                ['text' => json_encode(['diagnosis' => $diagnosis, 'treatment' => $treatment])],
+            ],
+        ]),
+    ]);
+}
+
+it('el botón IA completa diagnóstico y tratamiento en el form top-level', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse();
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertFormSet([
+            'diagnosis' => 'Diagnóstico IA',
+            'treatment' => 'Tratamiento IA',
+        ]);
+});
+
+it('el botón IA pide confirmación en el form top-level si ya hay diagnóstico o tratamiento cargado', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse();
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+            'diagnosis' => 'Diagnóstico escrito a mano',
+        ])
+        ->mountFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertFormComponentActionMounted('aiSuggestAction', 'aiSuggest');
+});
+
+it('el botón IA muestra notificación de error si la API falla en el form top-level', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(null, 500),
+    ]);
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertNotified('Error al generar sugerencia');
+});
+
+it('el botón IA completa diagnóstico y tratamiento dentro de la ficha de la mascota', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse();
+
+    // pageClass debe ser EditPet, no ViewPet: Filament vuelve las RelationManagers de
+    // solo lectura en páginas ViewRecord por defecto, lo que deshabilitaría la action 'create'.
+    Livewire::test(ConsultationsRelationManager::class, [
+        'ownerRecord' => $pet,
+        'pageClass' => EditPet::class,
+    ])
+        ->mountTableAction('create')
+        ->setTableActionData(['anamnesis' => 'Anamnesis de prueba'])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest', formName: 'mountedTableActionForm')
+        ->assertFormSet([
+            'diagnosis' => 'Diagnóstico IA',
+            'treatment' => 'Tratamiento IA',
+        ], 'mountedTableActionForm');
+});

--- a/tests/Feature/Regression/ConsultationAiSuggestTest.php
+++ b/tests/Feature/Regression/ConsultationAiSuggestTest.php
@@ -59,6 +59,62 @@ it('el botón IA muestra una alerta de urgencia si la IA detecta una urgencia al
         ->assertNotified('Posible urgencia detectada');
 });
 
+it('el botón IA pide completar la anamnesis primero si está vacía en el form top-level', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Http::fake();
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => '',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertNotified('Completá la anamnesis primero');
+
+    Http::assertNothingSent();
+});
+
+it('el botón IA pide completar la anamnesis primero si está vacía dentro de la ficha de la mascota', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Http::fake();
+
+    Livewire::test(ConsultationsRelationManager::class, [
+        'ownerRecord' => $pet,
+        'pageClass' => EditPet::class,
+    ])
+        ->mountTableAction('create')
+        ->setTableActionData(['anamnesis' => ''])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest', formName: 'mountedTableActionForm')
+        ->assertNotified('Completá la anamnesis primero');
+
+    Http::assertNothingSent();
+});
+
+it('el form top-level muestra el texto de ayuda y el indicador de "generando" para el botón IA', function () {
+    actingAsRole('veterinarian');
+
+    Livewire::test(CreateConsultation::class)
+        ->assertSee('Revisá siempre la sugerencia antes de guardar')
+        ->assertSeeHtml('Generando sugerencia con IA');
+});
+
+it('el form dentro de la ficha de la mascota muestra el texto de ayuda y el indicador de "generando" para el botón IA', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Livewire::test(ConsultationsRelationManager::class, [
+        'ownerRecord' => $pet,
+        'pageClass' => EditPet::class,
+    ])
+        ->mountTableAction('create')
+        ->assertSee('Revisá siempre la sugerencia antes de guardar')
+        ->assertSeeHtml('Generando sugerencia con IA');
+});
+
 it('el botón IA pide confirmación en el form top-level si ya hay diagnóstico o tratamiento cargado', function () {
     actingAsRole('veterinarian');
     $pet = Pet::factory()->create();

--- a/tests/Feature/Regression/ConsultationAiSuggestTest.php
+++ b/tests/Feature/Regression/ConsultationAiSuggestTest.php
@@ -11,13 +11,14 @@ beforeEach(function () {
     config(['services.anthropic.key' => 'test-key']);
 });
 
-function fakeAiResponse(string $diagnosis = 'Diagnóstico IA', string $treatment = 'Tratamiento IA'): void
+function fakeAiResponse(string $diagnosis = 'Diagnóstico IA', string $treatment = 'Tratamiento IA', string $urgency = 'baja'): void
 {
     Http::fake([
         'api.anthropic.com/*' => Http::response([
             'content' => [
-                ['text' => json_encode(['diagnosis' => $diagnosis, 'treatment' => $treatment])],
+                ['text' => json_encode(['diagnosis' => $diagnosis, 'treatment' => $treatment, 'urgency' => $urgency])],
             ],
+            'usage' => ['input_tokens' => 100, 'output_tokens' => 50],
         ]),
     ]);
 }
@@ -36,7 +37,26 @@ it('el botón IA completa diagnóstico y tratamiento en el form top-level', func
         ->assertFormSet([
             'diagnosis' => 'Diagnóstico IA',
             'treatment' => 'Tratamiento IA',
+            'ai_diagnosis_suggestion' => 'Diagnóstico IA',
+            'ai_treatment_suggestion' => 'Tratamiento IA',
+            'ai_urgency' => 'baja',
+            'ai_input_tokens' => 100,
+            'ai_output_tokens' => 50,
         ]);
+});
+
+it('el botón IA muestra una alerta de urgencia si la IA detecta una urgencia alta', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse(urgency: 'alta');
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Convulsiones y dificultad respiratoria',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertNotified('Posible urgencia detectada');
 });
 
 it('el botón IA pide confirmación en el form top-level si ya hay diagnóstico o tratamiento cargado', function () {

--- a/tests/Feature/Regression/ConsultationAiUsageStatusTest.php
+++ b/tests/Feature/Regression/ConsultationAiUsageStatusTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Enums\AiUsageStatus;
+use App\Models\Consultation;
+
+it('retorna Manual si la consulta nunca usó sugerencia de IA', function () {
+    $consultation = Consultation::factory()->create([
+        'ai_suggested_at' => null,
+        'ai_diagnosis_suggestion' => null,
+        'ai_treatment_suggestion' => null,
+    ]);
+
+    expect($consultation->aiUsageStatus())->toBe(AiUsageStatus::Manual);
+});
+
+it('retorna UsedAsIs si el diagnóstico y tratamiento final coinciden con la sugerencia de la IA', function () {
+    $consultation = Consultation::factory()->create([
+        'diagnosis' => 'Gastroenteritis',
+        'treatment' => 'Dieta blanda',
+        'ai_diagnosis_suggestion' => 'Gastroenteritis',
+        'ai_treatment_suggestion' => 'Dieta blanda',
+        'ai_suggested_at' => now(),
+    ]);
+
+    expect($consultation->aiUsageStatus())->toBe(AiUsageStatus::UsedAsIs);
+});
+
+it('retorna Edited si el veterinario modificó el diagnóstico o tratamiento sugerido por la IA', function () {
+    $consultation = Consultation::factory()->create([
+        'diagnosis' => 'Gastroenteritis aguda confirmada por palpación',
+        'treatment' => 'Dieta blanda',
+        'ai_diagnosis_suggestion' => 'Gastroenteritis',
+        'ai_treatment_suggestion' => 'Dieta blanda',
+        'ai_suggested_at' => now(),
+    ]);
+
+    expect($consultation->aiUsageStatus())->toBe(AiUsageStatus::Edited);
+});

--- a/tests/Feature/Regression/ConsultationAssignsPetAndUserTest.php
+++ b/tests/Feature/Regression/ConsultationAssignsPetAndUserTest.php
@@ -11,6 +11,7 @@ it('crear una consulta desde el listado top-level asigna pet_id y user_id', func
     Livewire::test(CreateConsultation::class)
         ->fillForm([
             'pet_id' => $pet->id,
+            'consultation_date' => now()->format('Y-m-d'),
             'anamnesis' => 'Anamnesis de prueba',
             'diagnosis' => 'Diagnóstico de prueba',
             'treatment' => 'Tratamiento de prueba',

--- a/tests/Feature/Regression/ConsultationExcludesInactivePetsTest.php
+++ b/tests/Feature/Regression/ConsultationExcludesInactivePetsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Filament\Resources\ConsultationResource\Pages\CreateConsultation;
+use App\Filament\Resources\ConsultationResource\Pages\EditConsultation;
+use App\Models\Consultation;
+use App\Models\Pet;
+use Livewire\Livewire;
+
+it('no ofrece mascotas inactivas al crear una consulta', function () {
+    actingAsRole('veterinarian');
+    $activePet = Pet::factory()->create(['active' => true]);
+    $inactivePet = Pet::factory()->inactiva()->create();
+
+    $options = Livewire::test(CreateConsultation::class)
+        ->instance()
+        ->form
+        ->getComponent('data.pet_id')
+        ->getOptions();
+
+    expect(array_key_exists($activePet->id, $options))->toBeTrue()
+        ->and(array_key_exists($inactivePet->id, $options))->toBeFalse();
+});
+
+it('mantiene visible la mascota ya asociada al editar una consulta aunque luego se haya marcado inactiva', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create(['active' => true]);
+    $consultation = Consultation::factory()->create(['pet_id' => $pet->id]);
+
+    $pet->update(['active' => false]);
+
+    $options = Livewire::test(EditConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->instance()
+        ->form
+        ->getComponent('data.pet_id')
+        ->getOptions();
+
+    expect(array_key_exists($pet->id, $options))->toBeTrue();
+});

--- a/tests/Feature/Regression/ConsultationTableAndInfolistPolishTest.php
+++ b/tests/Feature/Regression/ConsultationTableAndInfolistPolishTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Filament\Resources\ConsultationResource\Pages\ListConsultations;
+use App\Filament\Resources\ConsultationResource\Pages\ViewConsultation;
+use App\Filament\Resources\PetResource;
+use App\Filament\Resources\UserResource;
+use App\Models\Consultation;
+use App\Models\Pet;
+use Livewire\Livewire;
+
+it('ordena la tabla de consultas por fecha de consulta más reciente primero', function () {
+    actingAsRole('veterinarian');
+    $antigua = Consultation::factory()->create(['consultation_date' => '2026-01-01']);
+    $reciente = Consultation::factory()->create(['consultation_date' => '2026-06-01']);
+
+    $records = Livewire::test(ListConsultations::class)
+        ->instance()
+        ->getTable()
+        ->getRecords();
+
+    expect($records->first()->id)->toBe($reciente->id)
+        ->and($records->last()->id)->toBe($antigua->id);
+});
+
+it('la columna de veterinario en la tabla top-level tiene el label correcto', function () {
+    actingAsRole('veterinarian');
+    Consultation::factory()->create();
+
+    Livewire::test(ListConsultations::class)
+        ->assertSee('Veterinario');
+});
+
+it('muestra la urgencia detectada por la IA como badge en la tabla', function () {
+    actingAsRole('veterinarian');
+    Consultation::factory()->create(['ai_urgency' => 'alta', 'ai_suggested_at' => now()]);
+
+    Livewire::test(ListConsultations::class)
+        ->assertSee('Alta');
+});
+
+it('preserva los saltos de línea de la anamnesis en la vista de detalle', function () {
+    actingAsRole('veterinarian');
+    $consultation = Consultation::factory()->create([
+        'anamnesis' => "Primer párrafo.\nSegundo párrafo.",
+    ]);
+
+    Livewire::test(ViewConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->assertSeeHtml('Primer párrafo.<br');
+});
+
+it('muestra la fecha de registro y última edición en la vista de detalle', function () {
+    actingAsRole('veterinarian');
+    $consultation = Consultation::factory()->create();
+
+    Livewire::test(ViewConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->assertSee('Registrado el')
+        ->assertSee('Última edición');
+});
+
+it('el enlace a la mascota está visible para cualquier rol clínico, pero el enlace al veterinario solo para admin', function () {
+    $pet = Pet::factory()->create();
+    $consultation = Consultation::factory()->create(['pet_id' => $pet->id]);
+    $petUrl = PetResource::getUrl('view', ['record' => $pet->id]);
+    $userUrl = UserResource::getUrl('view', ['record' => $consultation->user_id]);
+
+    actingAsRole('veterinarian');
+    Livewire::test(ViewConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->assertSeeHtml($petUrl)
+        ->assertDontSeeHtml($userUrl);
+
+    actingAsRole('admin');
+    Livewire::test(ViewConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->assertSeeHtml($petUrl)
+        ->assertSeeHtml($userUrl);
+});

--- a/tests/Feature/Regression/RecentConsultationsWidgetTest.php
+++ b/tests/Feature/Regression/RecentConsultationsWidgetTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Filament\Widgets\RecentConsultationsWidget;
+use App\Models\Consultation;
+use Livewire\Livewire;
+
+it('muestra la fecha de consulta, no la fecha de carga, en el widget de consultas recientes', function () {
+    actingAsRole('veterinarian');
+    Consultation::factory()->create(['consultation_date' => '2026-01-15']);
+
+    $columns = Livewire::test(RecentConsultationsWidget::class)
+        ->instance()
+        ->getTable()
+        ->getColumns();
+
+    $names = array_map(fn ($column) => $column->getName(), $columns);
+
+    expect($names)->toContain('consultation_date')
+        ->not->toContain('created_at');
+});

--- a/tests/Feature/Regression/RelationManagersEditableFromViewPageTest.php
+++ b/tests/Feature/Regression/RelationManagersEditableFromViewPageTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Filament\Resources\OwnerResource\Pages\ViewOwner;
+use App\Filament\Resources\OwnerResource\RelationManagers\PetsRelationManager;
+use App\Filament\Resources\PetResource\Pages\ViewPet;
+use App\Filament\Resources\PetResource\RelationManagers\ConsultationsRelationManager;
+use App\Models\Owner;
+use App\Models\Pet;
+use Livewire\Livewire;
+
+/**
+ * Filament vuelve de solo lectura (por defecto) las RelationManagers en páginas
+ * ViewRecord. Este proyecto depende de poder crear registros médicos y mascotas
+ * desde la ficha de detalle (ver CLAUDE.md), así que ese default se desactiva en
+ * AdminPanelProvider. Este test evita que alguien lo reactive sin darse cuenta.
+ */
+it('la action de crear consultas está habilitada al ver la ficha de la mascota', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Livewire::test(ConsultationsRelationManager::class, [
+        'ownerRecord' => $pet,
+        'pageClass' => ViewPet::class,
+    ])->assertTableActionEnabled('create');
+});
+
+it('la action de crear mascotas está habilitada al ver la ficha del propietario', function () {
+    actingAsRole('veterinarian');
+    $owner = Owner::factory()->create();
+
+    Livewire::test(PetsRelationManager::class, [
+        'ownerRecord' => $owner,
+        'pageClass' => ViewOwner::class,
+    ])->assertTableActionEnabled('create');
+});

--- a/tests/Feature/Regression/ViewConsultationRendersAiSectionTest.php
+++ b/tests/Feature/Regression/ViewConsultationRendersAiSectionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Filament\Resources\ConsultationResource\Pages\ViewConsultation;
+use App\Models\Consultation;
+use Livewire\Livewire;
+
+it('renderiza ViewConsultation sin datos de IA', function () {
+    actingAsRole('veterinarian');
+    $consultation = Consultation::factory()->create(['ai_suggested_at' => null]);
+
+    Livewire::test(ViewConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->assertSuccessful();
+});
+
+it('renderiza ViewConsultation con datos de IA y urgencia', function () {
+    actingAsRole('veterinarian');
+    $consultation = Consultation::factory()->create([
+        'diagnosis' => 'X',
+        'treatment' => 'Y',
+        'ai_diagnosis_suggestion' => 'X',
+        'ai_treatment_suggestion' => 'Y',
+        'ai_urgency' => 'emergencia',
+        'ai_suggested_at' => now(),
+        'ai_input_tokens' => 10,
+        'ai_output_tokens' => 20,
+    ]);
+
+    Livewire::test(ViewConsultation::class, ['record' => $consultation->getRouteKey()])
+        ->assertSuccessful();
+});

--- a/tests/Feature/Services/AIDiagnosticServiceTest.php
+++ b/tests/Feature/Services/AIDiagnosticServiceTest.php
@@ -4,13 +4,38 @@ use App\Models\Pet;
 use App\Services\AIDiagnosticService;
 use Illuminate\Support\Facades\Http;
 
-it('retorna diagnóstico y tratamiento cuando la API responde correctamente', function () {
+it('retorna diagnóstico, tratamiento, urgencia y tokens cuando la API responde correctamente', function () {
     config(['services.anthropic.key' => 'test-key']);
 
     Http::fake([
         'api.anthropic.com/*' => Http::response([
             'content' => [
-                ['text' => json_encode(['diagnosis' => 'Gastroenteritis', 'treatment' => 'Dieta blanda'])],
+                ['text' => json_encode(['diagnosis' => 'Gastroenteritis', 'treatment' => 'Dieta blanda', 'urgency' => 'media'])],
+            ],
+            'usage' => ['input_tokens' => 123, 'output_tokens' => 45],
+        ]),
+    ]);
+
+    $pet = Pet::factory()->create();
+
+    $result = app(AIDiagnosticService::class)->suggest($pet, 'Vómitos y diarrea desde ayer.');
+
+    expect($result)->toBe([
+        'diagnosis' => 'Gastroenteritis',
+        'treatment' => 'Dieta blanda',
+        'urgency' => 'media',
+        'input_tokens' => 123,
+        'output_tokens' => 45,
+    ]);
+});
+
+it('no lanza excepción si la urgencia viene ausente o inválida, y la devuelve como null', function () {
+    config(['services.anthropic.key' => 'test-key']);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'content' => [
+                ['text' => json_encode(['diagnosis' => 'Gastroenteritis', 'treatment' => 'Dieta blanda', 'urgency' => 'no-existe'])],
             ],
         ]),
     ]);
@@ -19,7 +44,9 @@ it('retorna diagnóstico y tratamiento cuando la API responde correctamente', fu
 
     $result = app(AIDiagnosticService::class)->suggest($pet, 'Vómitos y diarrea desde ayer.');
 
-    expect($result)->toBe(['diagnosis' => 'Gastroenteritis', 'treatment' => 'Dieta blanda']);
+    expect($result['urgency'])->toBeNull()
+        ->and($result['input_tokens'])->toBeNull()
+        ->and($result['output_tokens'])->toBeNull();
 });
 
 it('lanza una excepción si la API responde con error', function () {

--- a/tests/Feature/Services/AIDiagnosticServiceTest.php
+++ b/tests/Feature/Services/AIDiagnosticServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\Pet;
+use App\Services\AIDiagnosticService;
+use Illuminate\Support\Facades\Http;
+
+it('retorna diagnóstico y tratamiento cuando la API responde correctamente', function () {
+    config(['services.anthropic.key' => 'test-key']);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'content' => [
+                ['text' => json_encode(['diagnosis' => 'Gastroenteritis', 'treatment' => 'Dieta blanda'])],
+            ],
+        ]),
+    ]);
+
+    $pet = Pet::factory()->create();
+
+    $result = app(AIDiagnosticService::class)->suggest($pet, 'Vómitos y diarrea desde ayer.');
+
+    expect($result)->toBe(['diagnosis' => 'Gastroenteritis', 'treatment' => 'Dieta blanda']);
+});
+
+it('lanza una excepción si la API responde con error', function () {
+    config(['services.anthropic.key' => 'test-key']);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(null, 500),
+    ]);
+
+    $pet = Pet::factory()->create();
+
+    app(AIDiagnosticService::class)->suggest($pet, 'Anamnesis de prueba');
+})->throws(RuntimeException::class);
+
+it('lanza una excepción si la respuesta no tiene el formato JSON esperado', function () {
+    config(['services.anthropic.key' => 'test-key']);
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'content' => [
+                ['text' => 'esto no es JSON válido'],
+            ],
+        ]),
+    ]);
+
+    $pet = Pet::factory()->create();
+
+    app(AIDiagnosticService::class)->suggest($pet, 'Anamnesis de prueba');
+})->throws(RuntimeException::class);
+
+it('lanza una excepción sin llamar a la API si falta la API key', function () {
+    config(['services.anthropic.key' => null]);
+
+    Http::fake();
+
+    $pet = Pet::factory()->create();
+
+    try {
+        app(AIDiagnosticService::class)->suggest($pet, 'Anamnesis de prueba');
+    } catch (RuntimeException) {
+        // esperado
+    }
+
+    Http::assertNothingSent();
+});


### PR DESCRIPTION
## Summary

This PR significantly improves the AI-assisted diagnosis feature by adding urgency level detection, comprehensive audit trails, and better UX for managing AI suggestions. The system now tracks how AI suggestions are used (manual, as-is, or edited) and displays urgency warnings when the AI detects high-risk cases.

## Key Changes

### AI Service & Data Model
- **Urgency Detection**: `AIDiagnosticService` now returns urgency levels (`baja`, `media`, `alta`, `emergencia`) alongside diagnosis and treatment suggestions
- **Token Tracking**: Captures input/output token usage from Anthropic API for cost monitoring
- **Audit Trail**: New fields on `Consultation` model track:
  - `ai_diagnosis_suggestion` / `ai_treatment_suggestion` — raw AI output for comparison
  - `ai_urgency` — detected urgency level (enum-backed)
  - `ai_suggested_at` — timestamp of suggestion generation
  - `ai_input_tokens` / `ai_output_tokens` — API usage metrics
- **New Enums**: `AiUrgencyLevel` and `AiUsageStatus` with Filament color/label support

### Form UX Improvements
- **Confirmation Modal**: When AI suggestion would overwrite existing diagnosis/treatment, shows confirmation dialog with "Sobrescribir" action
- **Validation**: AI button now validates that pet is selected and anamnesis is filled before calling API
- **Urgency Alerts**: Displays danger notification when AI detects `alta` or `emergencia` urgency
- **Helper Text**: Added character limits (5000 max) and guidance text for anamnesis field
- **Loading Indicator**: Shows "Generando sugerencia con IA" during API call

### Form Structure
- Reorganized consultation forms into logical sections:
  - "Información general" — pet selection, consultation date
  - "Consulta" — anamnesis, AI button, diagnosis, treatment, observation
- Added `consultation_date` field (separate from `created_at`) to track when the visit occurred
- Pet selector now filters out inactive pets (but keeps currently-associated pet visible during edit)

### View & Display
- **ViewConsultation**: Enhanced infolist with:
  - Clickable pet/veterinarian links (vet link only for admin)
  - Consultation date, creation, and last edit timestamps
  - AI section showing urgency badge, usage status, and token counts
  - Preserved line breaks in anamnesis display
- **Table Sorting**: Consultations now ordered by `consultation_date DESC` (most recent first)
- **Urgency Badge**: Displays AI-detected urgency with color coding in tables

### Testing
- Comprehensive regression tests covering:
  - AI suggestion flow in both top-level form and relation manager
  - Urgency detection and alert notifications
  - Anamnesis validation before API call
  - Confirmation modal for overwriting existing content
  - Inactive pet filtering
  - AI usage status calculation (Manual/UsedAsIs/Edited)
  - ViewConsultation rendering with/without AI data
  - Widget display of consultation dates

### Database
- Two migrations:
  - `add_consultation_date_to_consultations_table` — new date field
  - `add_ai_tracking_to_consultations_table` — audit trail fields

### Configuration
- Added `ANTHROPIC_MODEL` env variable (defaults to `claude-opus-4-8`)
- Enhanced `AIDiagnosticService` with timeout (30s) and retry logic (2 attempts)
- Improved error handling and logging

## Notable Implementation Details

- The `aiSuggestOverwritesExisting()` helper method centralizes the logic for determining when confirmation is needed
- AI suggestion fields are stored separately from final diagnosis/treatment, enabling audit trails and the `aiUsageStatus()` method to detect if veterinarian edited the suggestion
- Pet filtering uses `modifyQueryUsing` closure to conditionally include inactive pets only if already associated with the consultation
- Relation manager forms now support the same AI features as the top-level resource form

https://claude.ai/code/session_012nVS2cJvH8s4KkeShNkFsP