### PR TITLE
fix: usar PHP 8.4 en el pipeline de deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
       environment_name: laravet
       run_tests: true
       run_migrations: true
+      php_version: '8.4'
     secrets:
       SSH_HOST: ${{ secrets.SSH_HOST }}
       SSH_PORT: ${{ secrets.SSH_PORT }}


### PR DESCRIPTION
## Summary

- El deploy manual (`workflow_dispatch`) empezó a fallar en el job `test`: `composer install` rechazaba el `composer.lock` porque varios paquetes (`symfony/clock`, `symfony/css-selector`, `symfony/event-dispatcher`, `symfony/string`, `symfony/translation`, `nesbot/carbon`) requieren PHP ≥8.4.1.
- El workflow reusable (`nextup-py/deploy-actions/laravel-deploy.yml`) instala PHP **8.3** por defecto vía su input `php_version`, pero `deploy.yml` de este repo nunca lo especificaba.
- `composer.lock` quedó con esos requisitos desde el commit `9161a84` ("install Pest...", 30/07) — un día después del último deploy exitoso (29/07) — por eso el problema pasó desapercibido hasta el primer intento de deploy posterior a ese cambio.
- `tests.yml` de este mismo repo ya corre en PHP 8.4 (por eso el CI del PR #8 pasó sin problema), así que el pipeline de deploy había quedado desactualizado respecto al resto del proyecto.

## Cambio

Un solo agregado en `.github/workflows/deploy.yml`:

```yaml
with:
  environment_name: laravet
  run_tests: true
  run_migrations: true
  php_version: '8.4'
```

## Test plan

- [x] Validé la sintaxis YAML del archivo modificado.
- [ ] Re-correr el workflow **Deploy** manualmente contra `main` una vez mergeado este PR.
  - Si el servidor de producción ya tiene PHP 8.4, el deploy debería completarse.
  - Si el servidor tiene una versión más vieja, el job `test` (que corre en el runner de GitHub) pasará, pero el paso de deploy por SSH podría fallar en `composer install --no-dev` en el propio servidor — en ese caso el script hace rollback automático (`trap rollback ERR`) y no deja producción en un estado roto; el log específico va a quedar en `storage/logs/deploy.log` del servidor.

https://claude.ai/code/session_012nVS2cJvH8s4KkeShNkFsP

---
_Generated by [Claude Code](https://claude.ai/code/session_012nVS2cJvH8s4KkeShNkFsP)_