### PR TITLE
Mejorar UX del diagnóstico asistido por IA

### DIFF
--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\AiUsageStatus;
 use App\Filament\Concerns\ClinicRoles;
 use App\Filament\Concerns\HasClinicResourceAuthorization;
 use App\Filament\Resources\ConsultationResource\Pages;
@@ -49,6 +50,66 @@ class ConsultationResource extends Resource
     protected static function aiSuggestOverwritesExisting(Get $get): bool
     {
         return filled($get('diagnosis')) || filled($get('treatment'));
+    }
+
+    protected static function aiEditedHelperText(Get $get): string
+    {
+        $consultation = new Consultation([
+            'diagnosis' => $get('diagnosis'),
+            'treatment' => $get('treatment'),
+            'ai_diagnosis_suggestion' => $get('ai_diagnosis_suggestion'),
+            'ai_treatment_suggestion' => $get('ai_treatment_suggestion'),
+            'ai_suggested_at' => $get('ai_suggested_at'),
+        ]);
+
+        return $consultation->aiUsageStatus() === AiUsageStatus::Edited
+            ? '✏️ Editado respecto a la sugerencia de la IA. Máximo 5000 caracteres.'
+            : 'Máximo 5000 caracteres.';
+    }
+
+    protected static function aiUrgencyBadge(?string $urgency): HtmlString
+    {
+        $labels = [
+            'baja' => 'Baja',
+            'media' => 'Media',
+            'alta' => 'Alta',
+            'emergencia' => 'Emergencia',
+        ];
+
+        $classes = [
+            'baja' => 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300',
+            'media' => 'bg-info-100 text-info-700 dark:bg-info-500/20 dark:text-info-300',
+            'alta' => 'bg-warning-100 text-warning-700 dark:bg-warning-500/20 dark:text-warning-300',
+            'emergencia' => 'bg-danger-100 text-danger-700 dark:bg-danger-500/20 dark:text-danger-300',
+        ];
+
+        $label = $labels[$urgency] ?? $urgency;
+        $class = $classes[$urgency] ?? $classes['baja'];
+
+        return new HtmlString(
+            '<span class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium '.$class.'">'
+            .'Urgencia sugerida por la IA: '.e($label)
+            .'</span>'
+        );
+    }
+
+    protected static function aiErrorMessage(\RuntimeException $e): string
+    {
+        $message = $e->getMessage();
+
+        if (str_contains($message, 'ANTHROPIC_API_KEY')) {
+            return 'La integración con IA no está configurada. Contactá al administrador del sistema.';
+        }
+
+        if (str_contains($message, 'formato esperado')) {
+            return 'La IA devolvió una respuesta inesperada. Intentá nuevamente.';
+        }
+
+        if (str_contains($message, 'conectar con la API')) {
+            return 'No se pudo conectar con el servicio de IA. Verificá tu conexión e intentá nuevamente.';
+        }
+
+        return 'No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.';
     }
 
     public static function form(Form $form): Form
@@ -133,12 +194,20 @@ class ConsultationResource extends Resource
                                                 ->danger()
                                                 ->send();
                                         }
-                                    } catch (\Throwable $e) {
+                                    } catch (\RuntimeException $e) {
                                         Log::error('Error en sugerencia de IA: '.$e->getMessage());
 
                                         Notification::make()
                                             ->title('Error al generar sugerencia')
-                                            ->body('No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.')
+                                            ->body(static::aiErrorMessage($e))
+                                            ->danger()
+                                            ->send();
+                                    } catch (\Throwable $e) {
+                                        Log::error('Error inesperado en sugerencia de IA: '.$e->getMessage());
+
+                                        Notification::make()
+                                            ->title('Error al generar sugerencia')
+                                            ->body('Ocurrió un error inesperado. Intentá nuevamente en unos minutos.')
                                             ->danger()
                                             ->send();
                                     }
@@ -159,6 +228,11 @@ class ConsultationResource extends Resource
                                 .'Generando sugerencia con IA… esto puede tardar unos segundos.'
                                 .'</p>'
                             )),
+                        Forms\Components\Placeholder::make('aiUrgencyBadge')
+                            ->hiddenLabel()
+                            ->columnSpanFull()
+                            ->visible(fn (Get $get) => filled($get('ai_urgency')))
+                            ->content(fn (Get $get) => static::aiUrgencyBadge($get('ai_urgency'))),
                         Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
                         Forms\Components\Hidden::make('ai_treatment_suggestion'),
                         Forms\Components\Hidden::make('ai_urgency'),
@@ -170,14 +244,16 @@ class ConsultationResource extends Resource
                             ->columnSpanFull()
                             ->autosize()
                             ->maxLength(5000)
-                            ->helperText('Máximo 5000 caracteres.')
+                            ->live(onBlur: true)
+                            ->helperText(fn (Get $get) => static::aiEditedHelperText($get))
                             ->required(),
                         Forms\Components\Textarea::make('treatment')
                             ->label('Tratamiento')
                             ->columnSpanFull()
                             ->autosize()
                             ->maxLength(5000)
-                            ->helperText('Máximo 5000 caracteres.')
+                            ->live(onBlur: true)
+                            ->helperText(fn (Get $get) => static::aiEditedHelperText($get))
                             ->required(),
                         Forms\Components\Textarea::make('observation')
                             ->label('Observación')

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\PetResource\RelationManagers;
 
+use App\Enums\AiUsageStatus;
 use App\Filament\Concerns\ClinicRoles;
 use App\Filament\Concerns\HasClinicRelationManagerAuthorization;
 use App\Models\Consultation;
@@ -43,6 +44,66 @@ class ConsultationsRelationManager extends RelationManager
     protected function aiSuggestOverwritesExisting(Get $get): bool
     {
         return filled($get('diagnosis')) || filled($get('treatment'));
+    }
+
+    protected function aiEditedHelperText(Get $get): string
+    {
+        $consultation = new Consultation([
+            'diagnosis' => $get('diagnosis'),
+            'treatment' => $get('treatment'),
+            'ai_diagnosis_suggestion' => $get('ai_diagnosis_suggestion'),
+            'ai_treatment_suggestion' => $get('ai_treatment_suggestion'),
+            'ai_suggested_at' => $get('ai_suggested_at'),
+        ]);
+
+        return $consultation->aiUsageStatus() === AiUsageStatus::Edited
+            ? '✏️ Editado respecto a la sugerencia de la IA. Máximo 5000 caracteres.'
+            : 'Máximo 5000 caracteres.';
+    }
+
+    protected function aiUrgencyBadge(?string $urgency): HtmlString
+    {
+        $labels = [
+            'baja' => 'Baja',
+            'media' => 'Media',
+            'alta' => 'Alta',
+            'emergencia' => 'Emergencia',
+        ];
+
+        $classes = [
+            'baja' => 'bg-gray-100 text-gray-700 dark:bg-gray-500/20 dark:text-gray-300',
+            'media' => 'bg-info-100 text-info-700 dark:bg-info-500/20 dark:text-info-300',
+            'alta' => 'bg-warning-100 text-warning-700 dark:bg-warning-500/20 dark:text-warning-300',
+            'emergencia' => 'bg-danger-100 text-danger-700 dark:bg-danger-500/20 dark:text-danger-300',
+        ];
+
+        $label = $labels[$urgency] ?? $urgency;
+        $class = $classes[$urgency] ?? $classes['baja'];
+
+        return new HtmlString(
+            '<span class="inline-flex items-center rounded-full px-2 py-1 text-xs font-medium '.$class.'">'
+            .'Urgencia sugerida por la IA: '.e($label)
+            .'</span>'
+        );
+    }
+
+    protected function aiErrorMessage(\RuntimeException $e): string
+    {
+        $message = $e->getMessage();
+
+        if (str_contains($message, 'ANTHROPIC_API_KEY')) {
+            return 'La integración con IA no está configurada. Contactá al administrador del sistema.';
+        }
+
+        if (str_contains($message, 'formato esperado')) {
+            return 'La IA devolvió una respuesta inesperada. Intentá nuevamente.';
+        }
+
+        if (str_contains($message, 'conectar con la API')) {
+            return 'No se pudo conectar con el servicio de IA. Verificá tu conexión e intentá nuevamente.';
+        }
+
+        return 'No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.';
     }
 
     public function form(Form $form): Form
@@ -104,12 +165,20 @@ class ConsultationsRelationManager extends RelationManager
                                                 ->danger()
                                                 ->send();
                                         }
-                                    } catch (\Throwable $e) {
+                                    } catch (\RuntimeException $e) {
                                         Log::error('Error en sugerencia de IA: '.$e->getMessage());
 
                                         Notification::make()
                                             ->title('Error al generar sugerencia')
-                                            ->body('No se pudo generar la sugerencia. Intentá nuevamente en unos minutos.')
+                                            ->body($this->aiErrorMessage($e))
+                                            ->danger()
+                                            ->send();
+                                    } catch (\Throwable $e) {
+                                        Log::error('Error inesperado en sugerencia de IA: '.$e->getMessage());
+
+                                        Notification::make()
+                                            ->title('Error al generar sugerencia')
+                                            ->body('Ocurrió un error inesperado. Intentá nuevamente en unos minutos.')
                                             ->danger()
                                             ->send();
                                     }
@@ -129,6 +198,11 @@ class ConsultationsRelationManager extends RelationManager
                                 .'Generando sugerencia con IA… esto puede tardar unos segundos.'
                                 .'</p>'
                             )),
+                        Forms\Components\Placeholder::make('aiUrgencyBadge')
+                            ->hiddenLabel()
+                            ->columnSpanFull()
+                            ->visible(fn (Get $get) => filled($get('ai_urgency')))
+                            ->content(fn (Get $get) => $this->aiUrgencyBadge($get('ai_urgency'))),
                         Forms\Components\Hidden::make('ai_diagnosis_suggestion'),
                         Forms\Components\Hidden::make('ai_treatment_suggestion'),
                         Forms\Components\Hidden::make('ai_urgency'),
@@ -140,14 +214,16 @@ class ConsultationsRelationManager extends RelationManager
                             ->columnSpanFull()
                             ->autosize()
                             ->maxLength(5000)
-                            ->helperText('Máximo 5000 caracteres.')
+                            ->live(onBlur: true)
+                            ->helperText(fn (Get $get) => $this->aiEditedHelperText($get))
                             ->required(),
                         Forms\Components\Textarea::make('treatment')
                             ->label('Tratamiento')
                             ->columnSpanFull()
                             ->autosize()
                             ->maxLength(5000)
-                            ->helperText('Máximo 5000 caracteres.')
+                            ->live(onBlur: true)
+                            ->helperText(fn (Get $get) => $this->aiEditedHelperText($get))
                             ->required(),
                         Forms\Components\Textarea::make('observation')
                             ->label('Observación')

--- a/tests/Feature/Regression/ConsultationAiSuggestTest.php
+++ b/tests/Feature/Regression/ConsultationAiSuggestTest.php
@@ -4,6 +4,7 @@ use App\Filament\Resources\ConsultationResource\Pages\CreateConsultation;
 use App\Filament\Resources\PetResource\Pages\EditPet;
 use App\Filament\Resources\PetResource\RelationManagers\ConsultationsRelationManager;
 use App\Models\Pet;
+use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 
@@ -145,6 +146,128 @@ it('el botón IA muestra notificación de error si la API falla en el form top-l
         ])
         ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
         ->assertNotified('Error al generar sugerencia');
+});
+
+it('marca el diagnóstico y tratamiento como editados cuando difieren de la sugerencia de la IA en el form top-level', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse();
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertSee('Máximo 5000 caracteres.')
+        ->set('data.diagnosis', 'Diagnóstico IA modificado por el veterinario')
+        ->assertSee('Editado respecto a la sugerencia de la IA');
+});
+
+it('no marca el diagnóstico como editado si coincide con la sugerencia de la IA', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse();
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertDontSee('Editado respecto a la sugerencia de la IA');
+});
+
+it('muestra el badge de urgencia en el form top-level tras generar la sugerencia', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    fakeAiResponse(urgency: 'alta');
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertSee('Urgencia sugerida por la IA: Alta');
+});
+
+it('no muestra el badge de urgencia en el form top-level antes de generar sugerencia', function () {
+    actingAsRole('veterinarian');
+
+    Livewire::test(CreateConsultation::class)
+        ->assertDontSee('Urgencia sugerida por la IA');
+});
+
+it('muestra un mensaje específico si la API key de IA no está configurada', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    config(['services.anthropic.key' => null]);
+
+    Http::fake();
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertNotified(
+            Notification::make()
+                ->title('Error al generar sugerencia')
+                ->body('La integración con IA no está configurada. Contactá al administrador del sistema.')
+                ->danger()
+        );
+
+    Http::assertNothingSent();
+});
+
+it('muestra un mensaje específico si la respuesta de la IA no tiene el formato esperado', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'content' => [
+                ['text' => 'esto no es JSON válido'],
+            ],
+        ]),
+    ]);
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertNotified(
+            Notification::make()
+                ->title('Error al generar sugerencia')
+                ->body('La IA devolvió una respuesta inesperada. Intentá nuevamente.')
+                ->danger()
+        );
+});
+
+it('muestra un mensaje específico si falla la conexión con la API de IA', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+
+    Http::fake([
+        'api.anthropic.com/*' => Http::response(null, 500),
+    ]);
+
+    Livewire::test(CreateConsultation::class)
+        ->fillForm([
+            'pet_id' => $pet->id,
+            'anamnesis' => 'Anamnesis de prueba',
+        ])
+        ->callFormComponentAction('aiSuggestAction', 'aiSuggest')
+        ->assertNotified(
+            Notification::make()
+                ->title('Error al generar sugerencia')
+                ->body('No se pudo conectar con el servicio de IA. Verificá tu conexión e intentá nuevamente.')
+                ->danger()
+        );
 });
 
 it('el botón IA completa diagnóstico y tratamiento dentro de la ficha de la mascota', function () {


### PR DESCRIPTION
## Resumen
- Distingue cuando el diagnóstico/tratamiento fue editado respecto a la sugerencia de la IA (reutiliza `Consultation::aiUsageStatus()`), tanto en el formulario top-level de Consultas como en la ficha de la mascota.
- Muestra la urgencia detectada por la IA como badge visible en el propio formulario apenas se genera la sugerencia (antes solo se veía en la tabla).
- Diferencia los mensajes de error del botón "Asistir con IA": API key no configurada, respuesta con formato inválido, y fallo de conexión, en vez de un mensaje genérico único.
- El feedback de carga (botón deshabilitado + spinner) ya lo maneja Filament nativamente, no se tocó.

## Test plan
- [x] `php artisan test` — 63 tests, 295 assertions, todo verde.
- [x] `./vendor/bin/pint` — sin cambios de formato pendientes.
- [x] 7 tests nuevos en `ConsultationAiSuggestTest.php` cubriendo helper "editado", badge de urgencia y los 3 mensajes de error diferenciados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)