### PR TITLE
Agrupar acciones de fila en menú desplegable (todas las tablas)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,6 @@ correr el seeder por primera vez, ya no es fija).
 - Las imágenes de mascotas se suben con el editor de imágenes de Filament.
 - La base de datos por defecto es SQLite (`database/database.sqlite`). Para MySQL, configurar `DB_*` en `.env`.
 - Los seeders usan queries SQL con collation de MySQL para búsquedas de ciudades con acentos (ej: "Itauguá").
+- Estilo de imports (dos patrones distintos, según el paquete):
+  - **Sub-namespaces de Filament** (`Forms`, `Tables`, `Infolists`): se importa el namespace padre (`use Filament\Forms;`, `use Filament\Tables;`, `use Filament\Infolists;`) y se referencia el componente completo, ej. `Forms\Components\Select::make()`, `Tables\Columns\TextColumn::make()`, `Tables\Actions\EditAction::make()`, `Infolists\Components\TextEntry::make()`. No se importa cada componente individual.
+  - **Facades de Illuminate** (`Illuminate\Support\Facades\*`) y el resto del código (modelos, enums, servicios propios): se importa la clase individual arriba, ej. `use Illuminate\Support\Facades\Auth;`, y se usa `Auth::id()` directo.

--- a/app/Filament/Resources/CityResource.php
+++ b/app/Filament/Resources/CityResource.php
@@ -88,8 +88,10 @@ class CityResource extends Resource
             ])
             ->filters([])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/CityResource/RelationManagers/NeighborhoodsRelationManager.php
+++ b/app/Filament/Resources/CityResource/RelationManagers/NeighborhoodsRelationManager.php
@@ -49,8 +49,10 @@ class NeighborhoodsRelationManager extends RelationManager
                 Tables\Actions\CreateAction::make(),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -324,9 +324,11 @@ class ConsultationResource extends Resource
                     }),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/DepartmentResource.php
+++ b/app/Filament/Resources/DepartmentResource.php
@@ -65,8 +65,10 @@ class DepartmentResource extends Resource
             ])
             ->filters([])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/DepartmentResource/RelationManagers/CitiesRelationManager.php
+++ b/app/Filament/Resources/DepartmentResource/RelationManagers/CitiesRelationManager.php
@@ -56,8 +56,10 @@ class CitiesRelationManager extends RelationManager
                 Tables\Actions\CreateAction::make(),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/NeighborhoodResource.php
+++ b/app/Filament/Resources/NeighborhoodResource.php
@@ -65,8 +65,10 @@ class NeighborhoodResource extends Resource
             ])
             ->filters([])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/OwnerResource.php
+++ b/app/Filament/Resources/OwnerResource.php
@@ -187,9 +187,11 @@ class OwnerResource extends Resource
                     ->preload(),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/OwnerResource/RelationManagers/PetsRelationManager.php
+++ b/app/Filament/Resources/OwnerResource/RelationManagers/PetsRelationManager.php
@@ -75,8 +75,10 @@ class PetsRelationManager extends RelationManager
                     }),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/PetResource.php
+++ b/app/Filament/Resources/PetResource.php
@@ -220,9 +220,11 @@ class PetResource extends Resource
                     ->label('Estado'),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/ConsultationsRelationManager.php
@@ -300,8 +300,10 @@ class ConsultationsRelationManager extends RelationManager
                     }),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/PetResource/RelationManagers/SurgeriesRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/SurgeriesRelationManager.php
@@ -114,8 +114,10 @@ class SurgeriesRelationManager extends RelationManager
                     }),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/PetResource/RelationManagers/TestsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/TestsRelationManager.php
@@ -125,8 +125,10 @@ class TestsRelationManager extends RelationManager
                     }),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/PetResource/RelationManagers/VaccinationsRelationManager.php
+++ b/app/Filament/Resources/PetResource/RelationManagers/VaccinationsRelationManager.php
@@ -179,8 +179,10 @@ class VaccinationsRelationManager extends RelationManager
                     ->modalDescription('¿Desea descargar el PDF con el historial completo?'),
             ])
             ->actions([
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/SurgeryResource.php
+++ b/app/Filament/Resources/SurgeryResource.php
@@ -138,9 +138,11 @@ class SurgeryResource extends Resource
             ])
             ->filters([])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/TestResource.php
+++ b/app/Filament/Resources/TestResource.php
@@ -158,9 +158,11 @@ class TestResource extends Resource
             ])
             ->filters([])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -154,9 +154,11 @@ class UserResource extends Resource
                     ->options(self::roleOptions()),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/VaccinationResource.php
+++ b/app/Filament/Resources/VaccinationResource.php
@@ -208,9 +208,11 @@ class VaccinationResource extends Resource
                     ->query(fn (Builder $query) => $query->whereBetween('next_application', [now(), now()->addDays(7)])),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
-                Tables\Actions\DeleteAction::make(),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\ViewAction::make(),
+                    Tables\Actions\EditAction::make(),
+                    Tables\Actions\DeleteAction::make(),
+                ]),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/tests/Feature/Regression/TableActionsGroupedTest.php
+++ b/tests/Feature/Regression/TableActionsGroupedTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Filament\Resources\ConsultationResource\Pages\ListConsultations;
+use App\Filament\Resources\PetResource\Pages\EditPet;
+use App\Filament\Resources\PetResource\RelationManagers\ConsultationsRelationManager;
+use App\Models\Consultation;
+use App\Models\Pet;
+use Livewire\Livewire;
+
+/**
+ * Las acciones de fila (Ver/Editar/Eliminar) están agrupadas dentro de un
+ * Tables\Actions\ActionGroup para reducir el ruido visual. Este test confirma
+ * que, aun agrupadas, siguen siendo accesibles y funcionales por su nombre —
+ * si alguien las desagrupa o les cambia el nombre sin querer, esto lo detecta.
+ */
+it('las acciones de fila siguen existiendo y habilitadas dentro del ActionGroup en el form top-level', function () {
+    actingAsRole('veterinarian');
+    $consultation = Consultation::factory()->create();
+
+    Livewire::test(ListConsultations::class)
+        ->assertTableActionExists('view')
+        ->assertTableActionExists('edit')
+        ->assertTableActionExists('delete')
+        ->assertTableActionEnabled('view', $consultation)
+        ->assertTableActionEnabled('edit', $consultation)
+        ->assertTableActionEnabled('delete', $consultation);
+});
+
+it('las acciones de fila siguen existiendo y habilitadas dentro del ActionGroup en la ficha de la mascota', function () {
+    actingAsRole('veterinarian');
+    $pet = Pet::factory()->create();
+    $consultation = Consultation::factory()->create(['pet_id' => $pet->id]);
+
+    Livewire::test(ConsultationsRelationManager::class, [
+        'ownerRecord' => $pet,
+        'pageClass' => EditPet::class,
+    ])
+        ->assertTableActionExists('edit')
+        ->assertTableActionExists('delete')
+        ->assertTableActionEnabled('edit', $consultation)
+        ->assertTableActionEnabled('delete', $consultation);
+});


### PR DESCRIPTION
## Resumen
- Agrupa las acciones por fila (Ver/Editar/Eliminar, o Editar/Eliminar donde no hay Ver) en un `Tables\Actions\ActionGroup` en los 17 Resources/RelationManagers del panel admin, reemplazando los íconos sueltos por un menú desplegable "...".
- Incluye: ConsultationResource, ConsultationsRelationManager, VaccinationResource, VaccinationsRelationManager, SurgeryResource, SurgeriesRelationManager, TestResource, TestsRelationManager, OwnerResource, PetsRelationManager, PetResource, UserResource, CityResource, NeighborhoodsRelationManager, DepartmentResource, CitiesRelationManager, NeighborhoodResource.
- Documenta en CLAUDE.md el estilo de imports que el proyecto ya sigue consistentemente (namespace padre para sub-namespaces de Filament vs. clase individual para Facades/código propio) — quedó pendiente de commitear de una conversación anterior.

## Test plan
- [x] `php artisan test` — 63 tests, 295 assertions, todo verde.
- [x] `./vendor/bin/pint --test` sobre los archivos tocados — sin diferencias de formato.
- [x] `php -l` en los 17 archivos — sin errores de sintaxis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)