### PR TITLE
Unificar grupos de navegación del sidebar

### DIFF
--- a/app/Filament/Pages/ClinicSettingsPage.php
+++ b/app/Filament/Pages/ClinicSettingsPage.php
@@ -19,6 +19,8 @@ class ClinicSettingsPage extends Page implements HasForms
 
     protected static ?string $navigationGroup = 'Configuración';
 
+    protected static ?int $navigationSort = 1;
+
     protected static ?string $navigationLabel = 'Datos de la clínica';
 
     protected static ?string $title = 'Datos de la clínica';

--- a/app/Filament/Resources/CityResource.php
+++ b/app/Filament/Resources/CityResource.php
@@ -18,11 +18,11 @@ class CityResource extends Resource
 {
     protected static ?string $model = City::class;
 
-    protected static ?string $navigationGroup = 'Gestión del sistema';
+    protected static ?string $navigationGroup = 'Configuración';
 
     protected static ?string $navigationIcon = 'heroicon-o-building-office-2';
 
-    protected static ?int $navigationSort = 4;
+    protected static ?int $navigationSort = 5;
 
     protected static ?string $modelLabel = 'ciudad';
 

--- a/app/Filament/Resources/ConsultationResource.php
+++ b/app/Filament/Resources/ConsultationResource.php
@@ -31,6 +31,8 @@ class ConsultationResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-chat-bubble-left-right';
 
+    protected static ?int $navigationSort = 1;
+
     protected static ?string $modelLabel = 'consulta';
 
     protected static function aiSuggestOverwritesExisting(Get $get): bool

--- a/app/Filament/Resources/DepartmentResource.php
+++ b/app/Filament/Resources/DepartmentResource.php
@@ -18,11 +18,11 @@ class DepartmentResource extends Resource
 {
     protected static ?string $model = Department::class;
 
-    protected static ?string $navigationGroup = 'Gestión del sistema';
+    protected static ?string $navigationGroup = 'Configuración';
 
     protected static ?string $navigationIcon = 'heroicon-o-building-library';
 
-    protected static ?int $navigationSort = 3;
+    protected static ?int $navigationSort = 4;
 
     protected static ?string $modelLabel = 'departamento';
 

--- a/app/Filament/Resources/NeighborhoodResource.php
+++ b/app/Filament/Resources/NeighborhoodResource.php
@@ -17,11 +17,11 @@ class NeighborhoodResource extends Resource
 {
     protected static ?string $model = Neighborhood::class;
 
-    protected static ?string $navigationGroup = 'Gestión del sistema';
+    protected static ?string $navigationGroup = 'Configuración';
 
     protected static ?string $navigationIcon = 'heroicon-o-home-modern';
 
-    protected static ?int $navigationSort = 5;
+    protected static ?int $navigationSort = 6;
 
     protected static ?string $modelLabel = 'barrio';
 

--- a/app/Filament/Resources/OwnerResource.php
+++ b/app/Filament/Resources/OwnerResource.php
@@ -28,6 +28,8 @@ class OwnerResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-user';
 
+    protected static ?int $navigationSort = 2;
+
     protected static ?string $modelLabel = 'propietario';
 
     public static function form(Form $form): Form

--- a/app/Filament/Resources/PetResource.php
+++ b/app/Filament/Resources/PetResource.php
@@ -27,6 +27,8 @@ class PetResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-identification';
 
+    protected static ?int $navigationSort = 1;
+
     protected static ?string $modelLabel = 'mascota';
 
     /**

--- a/app/Filament/Resources/SurgeryResource.php
+++ b/app/Filament/Resources/SurgeryResource.php
@@ -23,6 +23,8 @@ class SurgeryResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-scissors';
 
+    protected static ?int $navigationSort = 3;
+
     protected static ?string $modelLabel = 'cirugía';
 
     public static function typeOptions(): array

--- a/app/Filament/Resources/TestResource.php
+++ b/app/Filament/Resources/TestResource.php
@@ -23,6 +23,8 @@ class TestResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-beaker';
 
+    protected static ?int $navigationSort = 4;
+
     protected static ?string $modelLabel = 'prueba laboratorial';
 
     protected static ?string $pluralModelLabel = 'pruebas laboratoriales';

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -26,11 +26,11 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static ?string $navigationGroup = 'Administración';
+    protected static ?string $navigationGroup = 'Configuración';
 
     protected static ?string $navigationIcon = 'heroicon-o-user-group';
 
-    protected static ?int $navigationSort = 2;
+    protected static ?int $navigationSort = 3;
 
     protected static ?string $modelLabel = 'usuario';
 

--- a/app/Filament/Resources/VaccinationResource.php
+++ b/app/Filament/Resources/VaccinationResource.php
@@ -22,6 +22,8 @@ class VaccinationResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-shield-check';
 
+    protected static ?int $navigationSort = 2;
+
     protected static ?string $modelLabel = 'vacunación';
 
     protected static ?string $pluralModelLabel = 'vacunaciones';

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -7,6 +7,7 @@ use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\NavigationGroup;
 use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -64,6 +65,18 @@ class AdminPanelProvider extends PanelProvider
             ->favicon($favicon)
             ->colors([
                 'primary' => $primaryColor ? Color::hex($primaryColor) : Color::Amber,
+            ])
+            ->navigationGroups([
+                NavigationGroup::make()
+                    ->label('Historial clínico')
+                    ->icon('heroicon-o-clipboard-document-list'),
+                NavigationGroup::make()
+                    ->label('Pacientes')
+                    ->icon('heroicon-o-heart'),
+                NavigationGroup::make()
+                    ->label('Configuración')
+                    ->icon('heroicon-o-cog-6-tooth')
+                    ->collapsed(),
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -4,7 +4,7 @@ return [
     'shield_resource' => [
         'should_register_navigation' => true,
         'slug' => 'shield/roles',
-        'navigation_sort' => -1,
+        'navigation_sort' => 2,
         'navigation_badge' => true,
         'navigation_group' => true,
         'sub_navigation_position' => null,


### PR DESCRIPTION
## Resumen
- Fusiona los grupos **"Configuración"**, **"Administración"** y **"Gestión del sistema"** en uno solo (**"Configuración"**): Datos de la clínica, Roles y permisos, Usuarios, Departamentos, Ciudades, Barrios.
- Define los 3 grupos del sidebar explícitamente vía `navigationGroups()` en `AdminPanelProvider` (antes el orden dependía del descubrimiento de archivos, no era intencional):
  - **Historial clínico** — ícono `heroicon-o-clipboard-document-list`
  - **Pacientes** — ícono `heroicon-o-heart`
  - **Configuración** — ícono `heroicon-o-cog-6-tooth`, colapsado por defecto (tiene 6 entradas)
- De paso, ordena con `navigationSort` las entradas dentro de cada grupo:
  - Configuración: Datos de la clínica → Roles y permisos → Usuarios → Departamentos → Ciudades → Barrios
  - Historial clínico: Consultas → Vacunaciones → Cirugías → Pruebas Laboratoriales
  - Pacientes: Mascotas → Propietarios

## Test plan
- [x] `php artisan test` — 69 tests, 321 assertions, todo verde (sin tests que dependieran de los nombres/orden de grupos anteriores).
- [x] `./vendor/bin/pint --test` sobre los archivos tocados — sin diferencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)