### PR TITLE
Encolar el envío de recordatorios de vacunación

### DIFF
--- a/app/Notifications/VaccinationNotification.php
+++ b/app/Notifications/VaccinationNotification.php
@@ -3,21 +3,24 @@
 namespace App\Notifications;
 
 use App\Filament\Resources\PetResource;
+use App\Models\Vaccination;
 use App\Settings\ClinicSettings;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Queue\SerializesModels;
 
-class VaccinationNotification extends Notification
+class VaccinationNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use Queueable, SerializesModels;
 
-    protected $vaccination;
+    protected Vaccination $vaccination;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct($vaccination)
+    public function __construct(Vaccination $vaccination)
     {
         $this->vaccination = $vaccination;
     }


### PR DESCRIPTION
## Resumen

`VaccinationNotification` pasa a implementar `ShouldQueue`. Antes solo tenía el trait `Queueable`, que por sí solo **no** activa el encolado — la notificación se enviaba de forma síncrona igual, dentro del mismo proceso del comando `send:vaccination-notifications`.

### Por qué
Detectado al investigar el pipeline de deploy: en producción hay un worker de colas (`laravet-worker`, supervisado por Supervisor, `queue:work --sleep=3 --tries=3 --max-time=3600`) corriendo permanentemente sin ningún trabajo real que procesar, porque ninguna clase del proyecto implementaba `ShouldQueue` (`QUEUE_CONNECTION=sync` por defecto). Este cambio le da un uso real: si el servidor de correo se cuelga en el envío #3 de 50 recordatorios, ya no bloquea todo el comando — cada notificación se procesa independientemente, con reintentos automáticos (`--tries=3`, ya configurado en el worker).

### Cambios
- `VaccinationNotification implements ShouldQueue`, agrega el trait `SerializesModels` (estándar para notificaciones encoladas que referencian un modelo Eloquent, evita serializar el objeto completo con sus relaciones ya cargadas).
- Tipa el constructor (`Vaccination $vaccination` en vez de sin tipo).

Sin cambios de comportamiento en local/tests (`QUEUE_CONNECTION=sync` en `phpunit.xml`, así que las notificaciones se siguen procesando inline en el mismo request/comando).

## Test plan
- [x] `php artisan test` — 82 tests, 369 assertions, todo verde (incluye `VaccinationReminderNotResentTest`, que usa `Notification::fake()` y no depende de si la notificación está encolada o no).
- [x] `./vendor/bin/pint` — sin diferencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)