### PR TITLE
Corregir zona horaria del recordatorio de vacunación

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -8,4 +8,10 @@ Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
 
-Schedule::command('send:vaccination-notifications')->daily()->withoutOverlapping();
+// La app corre internamente en UTC (config('app.timezone') sin APP_TIMEZONE en
+// .env), así que sin esto ->daily() dispara a medianoche UTC, no a medianoche
+// en Paraguay.
+Schedule::command('send:vaccination-notifications')
+    ->daily()
+    ->timezone('America/Asuncion')
+    ->withoutOverlapping();


### PR DESCRIPTION
## Resumen

`send:vaccination-notifications` estaba programado para correr a medianoche en `config('app.timezone')`, que por defecto es **UTC** (no hay `APP_TIMEZONE` en `.env`). En producción eso significa que el recordatorio se dispararía a las **21:00 hora de Paraguay**, no a medianoche local.

### Cómo se detectó
- `date` en el servidor mostró el reloj del SO correctamente en `-03` (hora real de Paraguay).
- `php artisan schedule:list` mostraba la tarea como `0 0 * * *` — medianoche, pero en la zona horaria interna de Laravel (UTC), no la del servidor.

### Fix
Se agrega `->timezone('America/Asuncion')` puntualmente a esta tarea (`routes/console.php`), en vez de cambiar `APP_TIMEZONE` globalmente — el fix acotado no afecta cómo se interpretan el resto de las fechas de la app (`created_at`, `next_application`, filtros de fecha en las tablas), que hoy asumen UTC en varios lugares.

**Verificado** con `artisan schedule:list`: la expresión cron interna pasó de `0 0 * * *` a `0 3 * * *` (medianoche UTC-3 = medianoche en Asunción, mientras esa zona esté en ese offset).

## Test plan
- [x] `php artisan test` — 82 tests, 369 assertions, todo verde.
- [x] `php artisan schedule:list` — confirma el horario corregido.
- [x] `./vendor/bin/pint` — sin diferencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)